### PR TITLE
fix: entity, subscriber and ApiController bugs (v1.2.0 sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,127 @@
-# Unofficial Shoper Appstore Symfony 6 Bundle
-## General info
-This bundle contains everything necessary to code an application for Shoper. It gives the possibility to use both the OAuth system as well as the user / password. It is not official code provided by the Shoper software developers.
-Current version:
-> 1.1.0
+# Shoper Appstore Symfony Bundle
+
+Unofficial Symfony 6.4 bundle for building applications on the [Shoper Appstore](https://developers.shoper.pl/developers/appstore). Provides OAuth integration, REST API client, billing and webhook handling, Twig helpers, and Maker commands for scaffolding controllers. Not official Shoper software.
+
+Current version: **1.2.0**
 
 ## Table of contents
-* [Technologies](#technologies)
-* [Setup](#setup)
-* [Examples](#examples)
-* [Status](#status)
+
+- [Technologies](#technologies)
+- [Setup](#setup)
+- [Configuration](#configuration)
+- [Token refresh CRON](#token-refresh-cron)
+- [Error handling](#error-handling)
+- [Documentation](#documentation)
 
 ## Technologies
-* PHP 8.2
-* Symfony 6.4
-* Doctrine
-* Twig
-* HTTPClient
-* Symfony MakerBundle
+
+- PHP 8.2
+- Symfony 6.4 LTS
+- Doctrine ORM
+- Twig
+- Symfony HttpClient
+- Symfony MakerBundle
 
 ## Setup
-* Install Symfony 6.4 LTS
-* Add pankrok/shoper-appstore-bundle location your `composer.json` and run composer
 
-``` bash
-composer require pankrok/shoper-appstore-bundle "^1.1.0"
+Install via Composer:
+
+```bash
+composer require pankrok/shoper-appstore-bundle "^1.2.0"
 ```
 
-* create appstore.yaml in config/packages and fill in the data:
-```yaml
-shoper_appstore:
-    appId: appId    
-    appSecret: appSecret
-    appstoreSecret: appstoreSecret
-```
-create database tabels:
-``` bash
+Create the database tables:
+
+```bash
 php bin/console make:migration
 php bin/console doctrine:migrations:migrate
 ```
 
-token refresh
-``` bash
-php bin/console ShoperAppstoreBundle:TokenRefresh
+## Configuration
+
+### OAuth mode (Appstore)
+
+Create `config/packages/appstore.yaml`:
+
+```yaml
+shoper_appstore:
+    appId: your_app_id
+    appSecret: your_app_secret
+    appstoreSecret: your_appstore_secret
+    jssdk: https://dcsaascdn.net/js/dc-sdk-1.0.5.min.js
 ```
 
-## Examples
+### Basic Auth mode (admin username/password)
 
-* [ApiController](docs/APICONTROLLER.md) 
-* [Aurora forms](docs/AURORAFORMS.md)
-* [Auth](docs/AUTH.md) 
-* [Billing system](docs/BILLING.md) 
-* [Events](docs/EVENTS.md)
-* [Iframe init](docs/IFRAME.md)
-* [Resources](docs/RESOURCES.md)
-* [ShoperController](docs/SHOPERCONTROLLER.md)
-* [Twig filters](docs/TWIGFILTERS.md)
-* [Webhook](docs/WEBHOOK.md)
+```yaml
+shoper_appstore:
+    username: admin_username
+    password: admin_password
+    shopurl: https://yourshop.com
+    jssdk: https://dcsaascdn.net/js/dc-sdk-1.0.5.min.js
+```
 
-## Status
-> Project is: _in progress_ 
+## Token refresh CRON
+
+Run the token refresh command every 4 hours to keep OAuth tokens valid:
+
+```bash
+php bin/console shoper:token:refresh
+```
+
+Available options:
+
+| Option | Default | Description |
+|---|---|---|
+| `--limit` | `200` | Maximum number of tokens to refresh per run |
+| `--hours-ahead` | `23` | Refresh tokens expiring within this many hours (max 23) |
+
+Example crontab entry (every 4 hours):
+
+```
+0 */4 * * * cd /var/www/html && php bin/console shoper:token:refresh --limit=200 --hours-ahead=23
+```
+
+> **Note:** The old command name `ShoperAppstoreBundle:TokenRefresh` is kept as a BC alias.
+
+## Error handling
+
+All Shoper API errors throw `ShoperApiException`, which extends Symfony's `HttpException` and carries the original error code and description from the API response.
+
+The bundle ships an `ExceptionSubscriber` that automatically intercepts `ShoperApiException` and renders a clean Aurora-compatible error page instead of the Symfony debug page — no configuration needed.
+
+To override the error template in your application, create:
+
+```
+templates/bundles/Appstore/error.html.twig
+```
+
+Catching the exception manually in a controller:
+
+```php
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
+
+try {
+    $data = $api->product->get()->getBodyArray();
+} catch (ShoperApiException $e) {
+    // $e->getShoperError()            → 'invalid_token'
+    // $e->getShoperErrorDescription() → 'Token has expired'
+    // $e->getStatusCode()             → 401
+    throw $e;
+}
+```
+
+## Documentation
+
+| Topic | File |
+|---|---|
+| ApiController reference | [docs/APICONTROLLER.md](docs/APICONTROLLER.md) |
+| OAuth & Basic Auth | [docs/AUTH.md](docs/AUTH.md) |
+| Aurora forms | [docs/AURORAFORMS.md](docs/AURORAFORMS.md) |
+| Billing system | [docs/BILLING.md](docs/BILLING.md) |
+| Events | [docs/EVENTS.md](docs/EVENTS.md) |
+| Iframe / JS SDK | [docs/IFRAME.md](docs/IFRAME.md) |
+| API Resources | [docs/RESOURCES.md](docs/RESOURCES.md) |
+| Shoper Controller | [docs/SHOPERCONTROLLER.md](docs/SHOPERCONTROLLER.md) |
+| Twig filters | [docs/TWIGFILTERS.md](docs/TWIGFILTERS.md) |
+| Webhooks | [docs/WEBHOOK.md](docs/WEBHOOK.md) |

--- a/Resources/views/error.html.twig
+++ b/Resources/views/error.html.twig
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Error {{ status_code }}</title>
+    {% if shoper_js_sdk is defined and shoper_js_sdk %}
+        <script src="{{ shoper_js_sdk }}"></script>
+    {% endif %}
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 2rem 1rem;
+            background: #f4f5f7;
+            color: #333;
+        }
+        .shoper-error {
+            max-width: 480px;
+            margin: 3rem auto;
+            background: #fff;
+            border-radius: 6px;
+            border: 1px solid #dde1e7;
+            box-shadow: 0 1px 4px rgba(0,0,0,.07);
+            padding: 2rem 2rem 1.5rem;
+        }
+        .shoper-error__badge {
+            display: inline-block;
+            font-size: .72rem;
+            font-weight: 700;
+            letter-spacing: .06em;
+            text-transform: uppercase;
+            color: #c0392b;
+            background: #fef2f2;
+            border: 1px solid #fca5a5;
+            border-radius: 4px;
+            padding: .2rem .55rem;
+            margin-bottom: 1rem;
+        }
+        .shoper-error__desc {
+            font-size: .95rem;
+            line-height: 1.55;
+            color: #4a5568;
+            margin: 0;
+        }
+        .shoper-error__footer {
+            margin-top: 1.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid #eef0f3;
+            font-size: .75rem;
+            color: #a0aec0;
+        }
+    </style>
+</head>
+<body>
+    <div class="shoper-error">
+        <span class="shoper-error__badge">{{ error|default('api_error') }}</span>
+        <p class="shoper-error__desc">{{ error_description|default('An unexpected API error occurred.') }}</p>
+        <div class="shoper-error__footer">HTTP {{ status_code }}</div>
+    </div>
+</body>
+</html>

--- a/docs/APICONTROLLER.md
+++ b/docs/APICONTROLLER.md
@@ -1,40 +1,109 @@
-
 # ApiController
 
-ApiController is main object that can talk with shoper RestAPI
+`ApiController` is the central service for communicating with the Shoper REST API. Inject it into your Symfony controllers or services via the DI container.
 
-## ApiController functions:
+## Method reference
 
-### setParams(array $params, bool $checkHash = true): void  
-setting pararms of application creditionals or user creditionals, Hash check is required only for application instance in iframe
+### initFromRequest(array $params, bool $checkHash = true): void
 
-### refreshShopToken(Shops $shop): void
-sending request for token refresh for choosen shop entiti
+Initialises the shop context from Shoper iframe query parameters (`shop`, `place`, `timestamp`, `hash`). Verifies the HMAC hash by default. Automatically refreshes the OAuth token if it expires within 24 hours.
 
-### setBasicAuth(string $url = null, array $basicAuth = []): BearerInterface  
-allow to use user/password api authentication
+```php
+$api->initFromRequest($request->query->all());
+```
 
-### getParams()  
-return all parameters of ApiController
+---
 
-### setClient(BearerInterface $client): void  
-allow to insert custom HTTP client
+### refreshToken(Shops $shop): void
 
-### getClient()  
-returns current HTTP client
+Refreshes the OAuth token for the given shop entity. Used primarily in CRON commands.
 
-### setShopUrl(string $url): void
-allow to set current shop URL
+```php
+$api->refreshToken($shop);
+```
 
-### getShopUrl(): ?string  
-return shop url stirng
+---
 
-### setShop(Shops $shop)  
-allows you to set the entity of the store to communicate after RestAPI
+### useBasicAuth(?string $url = null, array $basicAuth = []): BearerInterface
 
-### getShop(): ?Shops  
-returning current shop entity
+Switches to HTTP Basic Auth (admin username / password) mode. Pass `$url` and `$basicAuth` to override YAML config values.
 
-### getAppId(): bool
-return true if bundle use appId
+```php
+$client = $api->useBasicAuth('https://myshop.pl', [
+    'login'    => 'admin',
+    'password' => 'secret',
+]);
+```
 
+---
+
+### getRequestParams(): array
+
+Returns the query parameters that were passed to `initFromRequest()`.
+
+```php
+$params = $api->getRequestParams();
+// $params['shop'], $params['place'], $params['timestamp']
+```
+
+---
+
+### setHttpClient(BearerInterface $client): void / getHttpClient(): BearerInterface
+
+Inject or retrieve the underlying HTTP client (useful for testing).
+
+---
+
+### setShopUrl(string $url): void / getShopUrl(): ?string
+
+Set or get the active shop URL string.
+
+---
+
+### bindShop(Shops $shop): void / getActiveShop(): ?Shops
+
+Bind a `Shops` entity as the current context, or retrieve the active one.
+
+```php
+$api->bindShop($shop);
+$shop = $api->getActiveShop();
+```
+
+---
+
+### isOAuthMode(): bool
+
+Returns `true` when the bundle is configured in OAuth (Appstore) mode (i.e. `appId` is set in config).
+
+```php
+if ($api->isOAuthMode()) { ... }
+```
+
+---
+
+## Deprecated methods
+
+The following method names were used in versions prior to 1.2.0. They are kept as aliases and will trigger `E_USER_DEPRECATED`. Migrate to the new names listed above.
+
+| Deprecated (≤ 1.1.x)       | Replacement (≥ 1.2.0)    |
+|-----------------------------|--------------------------|
+| `setParams()`               | `initFromRequest()`      |
+| `refreshShopToken()`        | `refreshToken()`         |
+| `setBasicAuth()`            | `useBasicAuth()`         |
+| `getParams()`               | `getRequestParams()`     |
+| `setClient()`               | `setHttpClient()`        |
+| `getClient()`               | `getHttpClient()`        |
+| `setShop()`                 | `bindShop()`             |
+| `getShop()`                 | `getActiveShop()`        |
+| `getAppId()`                | `isOAuthMode()`          |
+
+---
+
+## Resource access
+
+Resources are accessed as magic properties of `ApiController`. See [RESOURCES.md](RESOURCES.md) for the full list.
+
+```php
+$products = $api->product->get()->getBodyArray();
+$api->product->put(42, ['stock' => ['price' => 19.99]]);
+```

--- a/docs/AURORAFORMS.md
+++ b/docs/AURORAFORMS.md
@@ -1,6 +1,15 @@
 # Aurora forms
-AppstoreBundle has pre-configured forms styles for Aurora, to use them just add the following entry in the file _config/packages/twig.yaml_
+
+AppstoreBundle ships pre-configured form theme styles compatible with Shoper's Aurora design system.
+
+## Setup
+
+Add the form theme to `config/packages/twig.yaml`:
+
 ```yaml
 twig:
-    form_themes: ['@Appstore/form.html.twig']
+    form_themes:
+        - '@Appstore/form.html.twig'
 ```
+
+This applies Aurora-compatible styling to all Symfony forms rendered in your application's Twig templates.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,63 +1,86 @@
-AppstoreBundle allows you to log in using the data generated when creating the application
+# Authentication
+
+AppstoreBundle supports two authentication modes.
+
+## OAuth mode (Appstore)
+
+Configure `config/packages/appstore.yaml`:
+
 ```yaml
-# config/packages/appstore.yaml
 shoper_appstore:
-    appId: appId    
+    appId: appId
     appSecret: appSecret
     appstoreSecret: appstoreSecret
 ```
-or by creating an administrator in the store using his login and password (webapi access required)
+
+In OAuth mode the bundle handles token acquisition and refresh automatically. Inject `ApiController` and use resources directly:
+
+```php
+use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/index', name: 'index')]
+public function index(ApiController $api): Response
+{
+    try {
+        $data = $api->product->get()->getBodyArray();
+    } catch (ShoperApiException $e) {
+        throw $e;
+    }
+
+    return $this->render('index/index.html.twig', [
+        'data' => $data,
+    ]);
+}
+```
+
+## Basic Auth mode (admin username/password)
+
+Configure `config/packages/appstore.yaml`:
+
 ```yaml
-# config/packages/appstore.yaml
 shoper_appstore:
     username: adminUsername
     password: adminPassword
-    shopurl: https://shopurl.com
+    shopurl: https://yourshop.com
 ```
 
-in setBasicAuth method, define the token with the method setToken(string $ token) or log in using the auth() method which will return the token.
+Then call `useBasicAuth()` followed by `auth()` to obtain a token:
+
 ```php
-<?php
+#[Route('/index', name: 'index')]
+public function index(ApiController $api): Response
+{
+    $api->useBasicAuth()->auth();
 
-    #[Route('/index', name: 'index')]
-    public function index(ApiController $api): Response
-    {
-        $api->setBasicAuth()->auth();
-        /* 
-        * you can use toArray() method to recive array body of shop response:
-        * array(3) { ["access_token"]=> string(40) "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ["expires_in"]=> int(2592000) ["token_type"]=> string(6) "bearer" } 
-        */
-        $data = $api->product->get()->getBodyArray();
-        $$token = $api->getClient()->getToken();
+    $data  = $api->product->get()->getBodyArray();
+    $token = $api->getHttpClient()->getToken();
 
-        return $this->renderForm('index/index.html.twig', [
-            'controller_name' => 'IndexController',
-            'r' => $data
-        ]);
-    }
+    return $this->render('index/index.html.twig', [
+        'data' => $data,
+    ]);
+}
 ```
 
-setBasicAuth() allows you to use the SDK without putting any data into the YAML file.
+`useBasicAuth()` also accepts runtime credentials, bypassing the YAML config entirely:
+
 ```php
-<?php
+$api->useBasicAuth('https://yourshop.com', [
+    'username' => 'admin',
+    'password' => 'secret',
+])->auth();
 
-    #[Route('/index', name: 'index')]
-    public function index(ApiController $api): Response
-    {
-        $options = [
-            'username' => 'foo',
-            'password' => 'bar',
-        ];
-        $url = 'https://foo.bar';
-        
-        $api->setBasicAuth($url, $options)->auth();
-        $data = $api->product->get()->getBodyArray();
-        $data[] = $api->getClient()->getToken();
-
-        return $this->renderForm('index/index.html.twig', [
-            'controller_name' => 'IndexController',
-            'response' => $data
-        ]);
-    }
+$data = $api->product->get()->getBodyArray();
 ```
 
+## Deprecated method names
+
+The following names were renamed in 1.2.0. Old names still work but emit `E_USER_DEPRECATED`.
+
+| Deprecated (≤ 1.1.x) | Replacement (≥ 1.2.0) |
+|---|---|
+| `setBasicAuth()` | `useBasicAuth()` |
+| `getClient()` | `getHttpClient()` |
+| `setClient()` | `setHttpClient()` |

--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -1,12 +1,65 @@
-#Creating Billing addres
+# Billing system
 
-After registration in ShoperAppstore new aplication you have to add application URL for automatic messages \
-more info here [developers.shoper.pl](https://developers.shoper.pl/developers/appstore/billing-system)
+After registering a new application in Shoper Appstore you must configure an **Application URL** to receive automatic messages (billing events).
 
-AppstoreBundle can create Billing Controller from console:
+More info: [developers.shoper.pl — Billing system](https://developers.shoper.pl/developers/appstore/billing-system)
+
+## Generating the controller
 
 ```bash
- php bin/console make:shoper-billing-controller
+php bin/console make:shoper-billing-controller
 ```
 
-makre will create a controller that will handle all requests sent by Shoper to the application (installation, subscription, update, deletion)
+The maker generates a controller pre-wired to handle all five Shoper automatic messages:
+
+| Shoper action | Event fired |
+|---|---|
+| Application installation payment | `appstore.billing_install` |
+| Subscription payment | `appstore.billing_subscription` |
+| Application is installed | `appstore.install` |
+| Application is upgraded | `appstore.upgrade` |
+| Application is uninstalled | `appstore.uninstall` |
+
+## Generated controller
+
+```php
+namespace App\Controller;
+
+use PanKrok\ShoperAppstoreBundle\Controller\AppstoreBillingController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class BillingController extends AbstractController
+{
+    #[Route('/billing', name: 'billing_billing')]
+    public function index(Request $request, AppstoreBillingController $billing): Response
+    {
+        return $billing->init($request->request->all());
+    }
+}
+```
+
+> The route name **must** start with `billing_` — the bundle's `RequestSubscriber` skips HMAC verification for billing routes to allow Shoper's server-to-server calls through.
+
+## Reacting to billing events
+
+Subscribe to any billing event in your application:
+
+```php
+use PanKrok\ShoperAppstoreBundle\Events\BillingInstallEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: BillingInstallEvent::NAME)]
+class BillingInstallListener
+{
+    public function __invoke(BillingInstallEvent $event): void
+    {
+        $payload = $event->getPayload();
+        // $payload['shop'], $payload['action'], ...
+    }
+}
+```
+
+See [EVENTS.md](EVENTS.md) for the full list of available events.

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -1,11 +1,72 @@
-
 # Events
 
-Event | Description
---- | ---
-appstore.billing_install | fires when recive [Application installation payment](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#installation-paid) message
-appstore.billing_subscription | fires when recive [Subscription payment](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#subscription-paid) message
-appstore.install | fires when recive [Application is installed](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#install) message
-appstore.post_install | fires just before returning information about the correct installation of the application
-appstore.upgrade | fires when recive [Application is upgraded](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#upgrade) message
-appstore.uninstall | fires when recive [Application is uninstalled](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#uninstall) message
+AppstoreBundle dispatches events at each stage of the Shoper application lifecycle. Pre-events fire before the database operation; post-events fire after.
+
+## Event reference
+
+| Event constant | Event name | Trigger |
+|---|---|---|
+| `PreBillingInstallEvent::NAME` | `appstore.pre_billing_install` | Before processing an installation payment |
+| `BillingInstallEvent::NAME` | `appstore.billing_install` | [Application installation payment](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#installation-paid) received |
+| `PreBillingSubscriptionEvent::NAME` | `appstore.pre_billing_subscription` | Before processing a subscription payment |
+| `BillingSubscriptionEvent::NAME` | `appstore.billing_subscription` | [Subscription payment](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#subscription-paid) received |
+| `PreInstallEvent::NAME` | `appstore.pre_install` | Before saving a new shop installation to the database |
+| `InstallEvent::NAME` | `appstore.install` | [Application installed](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#install) — shop and token saved |
+| `PostInstallEvent::NAME` | `appstore.post_install` | After successful installation (token persisted) |
+| `PostBillingInstallEvent::NAME` | `appstore.post_billing_install` | After billing install event is processed |
+| `PreUpgradeEvent::NAME` | `appstore.pre_upgrade` | Before updating shop version in the database |
+| `UpgradeEvent::NAME` | `appstore.upgrade` | [Application upgraded](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#upgrade) — shop version and URL updated |
+| `PreUninstallEvent::NAME` | `appstore.pre_uninstall` | Before removing a shop from the database |
+| `UninstallEvent::NAME` | `appstore.uninstall` | [Application uninstalled](https://developers.shoper.pl/developers/appstore/billing-system/automatic-messages#uninstall) — shop and token removed |
+
+## Usage
+
+### Attribute-based listener (recommended)
+
+```php
+use PanKrok\ShoperAppstoreBundle\Events\InstallEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: InstallEvent::NAME)]
+class AppInstallListener
+{
+    public function __invoke(InstallEvent $event): void
+    {
+        $payload = $event->getPayload();
+        // $payload['shop']                — shop domain
+        // $payload['shop_url']            — full shop URL
+        // $payload['application_version'] — installed version
+    }
+}
+```
+
+### EventSubscriber
+
+```php
+use PanKrok\ShoperAppstoreBundle\Events\InstallEvent;
+use PanKrok\ShoperAppstoreBundle\Events\UninstallEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class AppLifecycleSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            InstallEvent::NAME   => 'onInstall',
+            UninstallEvent::NAME => 'onUninstall',
+        ];
+    }
+
+    public function onInstall(InstallEvent $event): void
+    {
+        $payload = $event->getPayload();
+        // provision tenant, send welcome email, etc.
+    }
+
+    public function onUninstall(UninstallEvent $event): void
+    {
+        $payload = $event->getPayload();
+        // clean up tenant data, etc.
+    }
+}
+```

--- a/docs/IFRAME.md
+++ b/docs/IFRAME.md
@@ -1,7 +1,38 @@
-# Iframe
+# Iframe integration
 
-The Shoper allows applications registered in the Appstore to be displayed in the store's administration panel via an iframe. AppstoreBundle has a configured JS SDK Shoper loading code as well as an iframe initiating code and Aurora styles, more information about JS SDK can be found in [developers.shoper.pl](https://developers.shoper.pl/developers/appstore/shop-integration/js-sdk) documentation\
-To use the TWIG template provided by AppstoreBundle in the main TWIG file of your project, attach:
+Shoper Appstore applications are displayed inside the store's administration panel via an iframe. AppstoreBundle provides automatic JS SDK loading and Aurora styles.
+
+More info: [developers.shoper.pl — JS SDK](https://developers.shoper.pl/developers/appstore/shop-integration/js-sdk)
+
+## JS SDK
+
+The SDK URL is configured in `config/packages/appstore.yaml`:
+
+```yaml
+shoper_appstore:
+    jssdk: https://dcsaascdn.net/js/dc-sdk-1.0.5.min.js
+```
+
+The bundle registers the URL as a Twig global variable `shoper_js_sdk` and includes it automatically on every request via `JsSdkSubscriber`.
+
+To include the SDK and iframe init snippet in your base Twig template:
+
 ```twig
 {% include '@Appstore/js_sdk.html.twig' %}
+```
+
+Place this inside the `<head>` or at the end of `<body>` in your layout file.
+
+## Context data (iframe params)
+
+When your app is opened in the iframe, Shoper passes context via query parameters (`shop`, `place`, `timestamp`, `hash`). The bundle reads and verifies these automatically in `RequestSubscriber` on every request.
+
+You can access them in a controller via `ApiController`:
+
+```php
+public function index(ApiController $api): Response
+{
+    $params = $api->getRequestParams();
+    // $params['shop'], $params['place'], $params['timestamp']
+}
 ```

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,80 +1,91 @@
 # Resources
 
-below you will find a list of all available resources in sdk
+All resources are accessed via `ApiController` using camelCase property names. Each resource supports the standard CRUD methods: `get()`, `post()`, `put()`, `delete()`.
 
-* [aboutPage](https://developers.shoper.pl/developers/api/resources/aboutpages)
-* [additionalField](https://developers.shoper.pl/developers/api/resources/additional-fields)
-* [applicationConfig](https://developers.shoper.pl/developers/api/resources/application-config)
-* [applicationLock](https://developers.shoper.pl/developers/api/resources/application-lock)
-* [applicationVersion](https://developers.shoper.pl/developers/api/resources/application-version)
-* [attribute](https://developers.shoper.pl/developers/api/resources/attributes)
-* [attributeGroup](https://developers.shoper.pl/developers/api/resources/attribute-groups)
-* [auction](https://developers.shoper.pl/developers/api/resources/auctions)
-* [auctionHouse](https://developers.shoper.pl/developers/api/resources/auction-houses)
-* [auctionOrder](https://developers.shoper.pl/developers/api/resources/auction-orders)
-* [availability](https://developers.shoper.pl/developers/api/resources/availabilitys)
-* [categoriesTree](https://developers.shoper.pl/developers/api/resources/categories-tree)
-* [category](https://developers.shoper.pl/developers/api/resources/categorys)
-* [collection](https://developers.shoper.pl/developers/api/resources/collections)
-* [currency](https://developers.shoper.pl/developers/api/resources/currencys)
-* [dashboardActivity](https://developers.shoper.pl/developers/api/resources/dashboard-activitys)
-* [dashboardStat](https://developers.shoper.pl/developers/api/resources/dashboard-stats)
-* [delivery](https://developers.shoper.pl/developers/api/resources/deliveries)
-* [gauge](https://developers.shoper.pl/developers/api/resources/gauges)
-* [geolocationCountry](https://developers.shoper.pl/developers/api/resources/geolocation-countrys)
-* [geolocationRegion](https://developers.shoper.pl/developers/api/resources/geolocation-regions)
-* [geolocationSubregion](https://developers.shoper.pl/developers/api/resources/geolocation-subregions)
-* [language](https://developers.shoper.pl/developers/api/resources/languages)
-* [loyaltyEvent](https://developers.shoper.pl/developers/api/resources/loyalty-events)
-* [metafield](https://developers.shoper.pl/developers/api/resources/metafields)
-* [metafieldValue](https://developers.shoper.pl/developers/api/resources/metafield-values)
-* [news](https://developers.shoper.pl/developers/api/resources/news)
-* [newsCategory](https://developers.shoper.pl/developers/api/resources/news-categorys)
-* [newsComment](https://developers.shoper.pl/developers/api/resources/news-comments)
-* [newsFile](https://developers.shoper.pl/developers/api/resources/news-files)
-* [newsTag](https://developers.shoper.pl/developers/api/resources/news-tags)
-* [objectMtime](https://developers.shoper.pl/developers/api/resources/object-mtime)
-* [option](https://developers.shoper.pl/developers/api/resources/options)
-* [optionGroup](https://developers.shoper.pl/developers/api/resources/option-groups)
-* [optionValue](https://developers.shoper.pl/developers/api/resources/option-values)
-* [order](https://developers.shoper.pl/developers/api/resources/orders)
-* [orderProduct](https://developers.shoper.pl/developers/api/resources/order-products)
-* [orderTag](https://developers.shoper.pl/developers/api/resources/order-tags)
-* [parcel](https://developers.shoper.pl/developers/api/resources/parcels)
-* [payment](https://developers.shoper.pl/developers/api/resources/payments)
-* [producer](https://developers.shoper.pl/developers/api/resources/producers)
-* [product](https://developers.shoper.pl/developers/api/resources/products)
-* [productFile](https://developers.shoper.pl/developers/api/resources/product-files)
-* [productImage](https://developers.shoper.pl/developers/api/resources/product-images)
-* [productStock](https://developers.shoper.pl/developers/api/resources/product-stocks)
-* [productTag](https://developers.shoper.pl/developers/api/resources/product-tags)
-* [progress](https://developers.shoper.pl/developers/api/resources/progresses)
-* [promotionCode](https://developers.shoper.pl/developers/api/resources/promotion-codes)
-* [redirect](https://developers.shoper.pl/developers/api/resources/redirects)
-* [shipping](https://developers.shoper.pl/developers/api/resources/shippings)
-* [specialOffer](https://developers.shoper.pl/developers/api/resources/special-offers)
-* [status](https://developers.shoper.pl/developers/api/resources/statuses)
-* [subscriber](https://developers.shoper.pl/developers/api/resources/subscribers)
-* [subscriberGroup](https://developers.shoper.pl/developers/api/resources/subscriber-groups)
-* [tax](https://developers.shoper.pl/developers/api/resources/taxs)
-* [unit](https://developers.shoper.pl/developers/api/resources/units)
-* [user](https://developers.shoper.pl/developers/api/resources/users)
-* [userAddress](https://developers.shoper.pl/developers/api/resources/user-addresses)
-* [userGroup](https://developers.shoper.pl/developers/api/resources/user-groups)
-* [warehouse](https://developers.shoper.pl/developers/api/resources/warehouses)
-* [warehouseLog](https://developers.shoper.pl/developers/api/resources/warehouse-logs)
-* [warehouseRelocation](https://developers.shoper.pl/developers/api/resources/warehouse-relocations)
-* [webhook](https://developers.shoper.pl/developers/api/resources/webhooks)
-* [zone](https://developers.shoper.pl/developers/api/resources/zones)
-
->example of getting resource:
+## Usage
 
 ```php
-<?php
+// GET list
+$products = $api->product->get()->getBodyArray();
 
-    public function index(ApiController $api): Response
-    {
-        $productResource = $api->product
-        
-    // rest of code...
+// GET single by ID
+$product = $api->product->get(42)->getBodyArray();
+
+// POST (create)
+$id = $api->product->post(['translations' => [...], 'stock' => [...]]);
+
+// PUT (update)
+$api->product->put(42, ['stock' => ['price' => 19.99]]);
+
+// DELETE
+$api->product->delete(42);
 ```
+
+## Available resources
+
+| Property name | Shoper API docs |
+|---|---|
+| `aboutPage` | [aboutpages](https://developers.shoper.pl/developers/api/resources/aboutpages) |
+| `additionalField` | [additional-fields](https://developers.shoper.pl/developers/api/resources/additional-fields) |
+| `applicationConfig` | [application-config](https://developers.shoper.pl/developers/api/resources/application-config) |
+| `applicationLock` | [application-lock](https://developers.shoper.pl/developers/api/resources/application-lock) |
+| `applicationVersion` | [application-version](https://developers.shoper.pl/developers/api/resources/application-version) |
+| `attribute` | [attributes](https://developers.shoper.pl/developers/api/resources/attributes) |
+| `attributeGroup` | [attribute-groups](https://developers.shoper.pl/developers/api/resources/attribute-groups) |
+| `auction` | [auctions](https://developers.shoper.pl/developers/api/resources/auctions) |
+| `auctionHouse` | [auction-houses](https://developers.shoper.pl/developers/api/resources/auction-houses) |
+| `auctionOrder` | [auction-orders](https://developers.shoper.pl/developers/api/resources/auction-orders) |
+| `availability` | [availabilitys](https://developers.shoper.pl/developers/api/resources/availabilitys) |
+| `categoriesTree` | [categories-tree](https://developers.shoper.pl/developers/api/resources/categories-tree) |
+| `category` | [categories](https://developers.shoper.pl/developers/api/resources/categorys) |
+| `collection` | [collections](https://developers.shoper.pl/developers/api/resources/collections) |
+| `currency` | [currencies](https://developers.shoper.pl/developers/api/resources/currencys) |
+| `dashboardActivity` | [dashboard-activity](https://developers.shoper.pl/developers/api/resources/dashboard-activitys) |
+| `dashboardStat` | [dashboard-stats](https://developers.shoper.pl/developers/api/resources/dashboard-stats) |
+| `delivery` | [deliveries](https://developers.shoper.pl/developers/api/resources/deliveries) |
+| `gauge` | [gauges](https://developers.shoper.pl/developers/api/resources/gauges) |
+| `geolocationCountry` | [geolocation-countries](https://developers.shoper.pl/developers/api/resources/geolocation-countrys) |
+| `geolocationRegion` | [geolocation-regions](https://developers.shoper.pl/developers/api/resources/geolocation-regions) |
+| `geolocationSubregion` | [geolocation-subregions](https://developers.shoper.pl/developers/api/resources/geolocation-subregions) |
+| `language` | [languages](https://developers.shoper.pl/developers/api/resources/languages) |
+| `loyaltyEvent` | [loyalty-events](https://developers.shoper.pl/developers/api/resources/loyalty-events) |
+| `metafield` | [metafields](https://developers.shoper.pl/developers/api/resources/metafields) |
+| `metafieldValue` | [metafield-values](https://developers.shoper.pl/developers/api/resources/metafield-values) |
+| `news` | [news](https://developers.shoper.pl/developers/api/resources/news) |
+| `newsCategory` | [news-categories](https://developers.shoper.pl/developers/api/resources/news-categorys) |
+| `newsComment` | [news-comments](https://developers.shoper.pl/developers/api/resources/news-comments) |
+| `newsFile` | [news-files](https://developers.shoper.pl/developers/api/resources/news-files) |
+| `newsTag` | [news-tags](https://developers.shoper.pl/developers/api/resources/news-tags) |
+| `objectMtime` | [object-mtime](https://developers.shoper.pl/developers/api/resources/object-mtime) |
+| `option` | [options](https://developers.shoper.pl/developers/api/resources/options) |
+| `optionGroup` | [option-groups](https://developers.shoper.pl/developers/api/resources/option-groups) |
+| `optionValue` | [option-values](https://developers.shoper.pl/developers/api/resources/option-values) |
+| `order` | [orders](https://developers.shoper.pl/developers/api/resources/orders) |
+| `orderProduct` | [order-products](https://developers.shoper.pl/developers/api/resources/order-products) |
+| `orderTag` | [order-tags](https://developers.shoper.pl/developers/api/resources/order-tags) |
+| `parcel` | [parcels](https://developers.shoper.pl/developers/api/resources/parcels) |
+| `payment` | [payments](https://developers.shoper.pl/developers/api/resources/payments) |
+| `producer` | [producers](https://developers.shoper.pl/developers/api/resources/producers) |
+| `product` | [products](https://developers.shoper.pl/developers/api/resources/products) |
+| `productFile` | [product-files](https://developers.shoper.pl/developers/api/resources/product-files) |
+| `productImage` | [product-images](https://developers.shoper.pl/developers/api/resources/product-images) |
+| `productStock` | [product-stocks](https://developers.shoper.pl/developers/api/resources/product-stocks) |
+| `productTag` | [product-tags](https://developers.shoper.pl/developers/api/resources/product-tags) |
+| `progress` | [progresses](https://developers.shoper.pl/developers/api/resources/progresses) |
+| `promotionCode` | [promotion-codes](https://developers.shoper.pl/developers/api/resources/promotion-codes) |
+| `redirect` | [redirects](https://developers.shoper.pl/developers/api/resources/redirects) |
+| `shipping` | [shippings](https://developers.shoper.pl/developers/api/resources/shippings) |
+| `specialOffer` | [special-offers](https://developers.shoper.pl/developers/api/resources/special-offers) |
+| `status` | [statuses](https://developers.shoper.pl/developers/api/resources/statuses) |
+| `subscriber` | [subscribers](https://developers.shoper.pl/developers/api/resources/subscribers) |
+| `subscriberGroup` | [subscriber-groups](https://developers.shoper.pl/developers/api/resources/subscriber-groups) |
+| `tax` | [taxes](https://developers.shoper.pl/developers/api/resources/taxs) |
+| `unit` | [units](https://developers.shoper.pl/developers/api/resources/units) |
+| `user` | [users](https://developers.shoper.pl/developers/api/resources/users) |
+| `userAddress` | [user-addresses](https://developers.shoper.pl/developers/api/resources/user-addresses) |
+| `userGroup` | [user-groups](https://developers.shoper.pl/developers/api/resources/user-groups) |
+| `warehouse` | [warehouses](https://developers.shoper.pl/developers/api/resources/warehouses) |
+| `warehouseLog` | [warehouse-logs](https://developers.shoper.pl/developers/api/resources/warehouse-logs) |
+| `warehouseRelocation` | [warehouse-relocations](https://developers.shoper.pl/developers/api/resources/warehouse-relocations) |
+| `webhook` | [webhooks](https://developers.shoper.pl/developers/api/resources/webhooks) |
+| `zone` | [zones](https://developers.shoper.pl/developers/api/resources/zones) |

--- a/docs/SHOPERCONTROLLER.md
+++ b/docs/SHOPERCONTROLLER.md
@@ -1,194 +1,127 @@
-# Creating Shoper contoller
+# Shoper Controller
 
-## Index
-* [Creating controller](#creating-controller)
-* [Get request](#single-request)
-* [Insert object](#insert-object)
-* [Updating object](#updating-object)
-* [Deleting object](#deleting-object)
-* [Bulk Request](#bulk-Request)
+## Generating the controller
 
-## Creating controller
 ```bash
- php bin/console make:shoper-controller
+php bin/console make:shoper-controller
 ```
-maker will create a controller that allows you to manage requests sent to the store as well as receive data, below is an example of the use of a controler. 
 
-## Get request
+The maker generates a controller pre-wired with `ApiController` injection and `ShoperApiException` error handling.
+
+## GET — fetch a resource list
+
 ```php
-<?php
-
 namespace App\Controller;
 
+use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
-use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
-
+use Symfony\Component\Routing\Attribute\Route;
 
 class IndexController extends AbstractController
 {
     #[Route('/', name: 'index')]
     public function index(ApiController $api): Response
     {
-        $data = $api->product->get();
-        
-        return $this->renderForm('index/index.html.twig', [
-            'controller_name' => 'IndexController',
+        try {
+            $data = $api->product->get()->getBodyArray();
+        } catch (ShoperApiException $e) {
+            throw $e;
+        }
+
+        return $this->render('index/index.html.twig', [
             'data' => $data,
         ]);
     }
 }
-
 ```
 
-## Insert object
-> Upon successful request, this method returns an identifier of created object
+## GET — fetch a single object by ID
+
 ```php
-<?php
-
-namespace App\Controller;
-
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
-use PanKrok\ShoperAppstoreBundle\Controller\AppController;
-
-
-class IndexController extends AbstractController
-{
-    #[Route('/', name: 'index')]
-    public function index(ApiController $api): Response
-    {
-        $data = [
-            'category_id' => 1,
-            'producer_id' => 1,
-            'translations' => [
-                'pl_PL' => [
-                    'name' => 'product name',
-                    'description' => 'product description',
-                    'active' => true
-                ]
-            ],
-            'stock' => [
-                'price' => 10,
-                'active' => 1,
-                'stock' => 10
-            ],
-            'tax_id' => 1,
-            'code' => '1234567',
-            'unit_id' => 1
-        ];
-        $result = $api->product->post($data);
-        printf("An object has been added #%d", $result);
-        
-        return new Response();
-    }
-}
-
+$product = $api->product->get(42)->getBodyArray();
 ```
 
-## Updating object
->Upon successful request, this method returns true.
+## POST — insert object
+
+> Upon success returns the ID of the created object.
+
 ```php
-<?php
+$data = [
+    'category_id' => 1,
+    'producer_id' => 1,
+    'translations' => [
+        'pl_PL' => [
+            'name'        => 'Product name',
+            'description' => 'Product description',
+            'active'      => true,
+        ],
+    ],
+    'stock' => [
+        'price'  => 10,
+        'active' => 1,
+        'stock'  => 10,
+    ],
+    'tax_id'  => 1,
+    'code'    => '1234567',
+    'unit_id' => 1,
+];
 
-namespace App\Controller;
-
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
-use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
-
-
-class IndexController extends AbstractController
-{
-    #[Route('/', name: 'index')]
-    public function index(ApiController $api): Response
-    {
-        $productId = 1;
-        $data = [
-            'stock' => [
-                'price' => 10,
-                'active' => 1,
-                'stock' => 10
-            ],
-        ];
-        $result = $api->product->put($productId, $data);
-        if($result){
-            echo 'A product has been successfully updated';
-        }
-        
-        return new Response();
-    }
-}
-
+$id = $api->product->post($data);
 ```
 
-## Delete object
->Upon successful request, no response is returned
+## PUT — update object
+
+> Upon success returns `true`.
+
 ```php
-<?php
+$productId = 42;
+$data = [
+    'stock' => [
+        'price' => 19.99,
+    ],
+];
 
-namespace App\Controller;
-
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
-use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
-
-
-class IndexController extends AbstractController
-{
-    #[Route('/', name: 'index')]
-    public function index(ApiController $api): Response
-    {
-        $id = 1;
-        $result = $api->product->delete($id);
-        if($result){
-            echo 'Product deleted';
-        }
-        
-        return new Response();
-    }
-}
-
+$result = $api->product->put($productId, $data);
 ```
 
-## Bulk Request
-> Bulk can use all shoper RestApi methods: _get(?id) post(?$data) put($id, $data) depete($id)_
+## DELETE — delete object
+
+> Upon success no response body is returned.
+
 ```php
-<?php
+$api->product->delete(42);
+```
 
-namespace App\Controller;
+## Filtering and pagination
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
-use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
+`setLimit()` accepts values between 1 and 50 (`ResourceModel::MAX_LIMIT`).
 
+```php
+$products = $api->product
+    ->setFilters(['stock.price' => ['gt' => 10]])
+    ->setOrder('add_date desc')
+    ->setLimit(50)
+    ->setPage(2)
+    ->get()
+    ->getBodyArray();
+```
 
-class IndexController extends AbstractController
-{
-    #[Route('/', name: 'index')]
-    public function index(ApiController $api): Response
-    {
-        $data = $api
-                    ->bulk
-                        ->product
-                            ->setLimit(1)
-                            ->setPage(1)
-                            ->get()
-                        ->product
-                            ->setLimit(1)
-                            ->setPage(2)
-                            ->get()
-                        ->send();
-        
-        return $this->renderForm('index/index.html.twig', [
-            'controller_name' => 'IndexController',
-            'data' => $data,
-        ]);
-    }
-}
+## Bulk requests
+
+Send multiple requests in one HTTP call. Bulk supports all CRUD methods.
+
+```php
+$results = $api->bulk
+    ->product
+        ->setLimit(10)
+        ->setPage(1)
+        ->get()
+    ->product
+        ->setLimit(10)
+        ->setPage(2)
+        ->get()
+    ->send()
+    ->getBodyArray();
 ```

--- a/docs/TWIGFILTERS.md
+++ b/docs/TWIGFILTERS.md
@@ -1,18 +1,30 @@
 # Twig filters
 
-## productImg
-Creating url to original img of product:
+All filters are registered automatically and available in every Twig template. They require the shop URL to be set on `ApiController` (happens automatically in OAuth iframe mode).
+
+## `productImg`
+
+Returns the URL to the original image file of a product.
+
 ```twig
-    {{ product.main_image.gfx_id | productImg }}
-```
-## productFrontUrl
-Creating url to front page of product:
-```twig
-    {{ product.product_id | productFrontUrl }}
+{{ product.main_image.gfx_id | productImg }}
 ```
 
-## productAdminUrl
-Creating url to administraton page of product:
+## `productFrontUrl`
+
+Returns the URL to the product's storefront page. Requires the product ID and name. Appends `?preview=true` by default (pass `false` as second argument to disable).
+
 ```twig
-    {{ product.product_id | productAdminUrl }}
+{{ product.product_id | productFrontUrl(product.translations.pl_PL.name) }}
+
+{# Without preview mode #}
+{{ product.product_id | productFrontUrl(product.translations.pl_PL.name, false) }}
+```
+
+## `productAdminUrl`
+
+Returns the URL to the product's edit page in the shop admin panel.
+
+```twig
+{{ product.product_id | productAdminUrl }}
 ```

--- a/docs/WEBHOOK.md
+++ b/docs/WEBHOOK.md
@@ -1,51 +1,76 @@
-# Creating Shoper webhook contoller
+# Webhooks
 
-Shoper allows you to create webhooks, AppstoreBundle allows you to create a controller that will receive the webhook and check its checksum.
+Shoper can send webhook notifications to your application. AppstoreBundle provides `WebhookController` to verify the request checksum and set up the API client for the calling shop.
+
+## Generating the controller
+
 ```bash
- php bin/console make:shoper-webhook-controller
+php bin/console make:shoper-webhook-controller
 ```
 
-the following code shows a simple use of the order.create webhook
-```php
-<?php
+The maker asks for a controller name and an optional webhook secret. The secret can also be configured later directly in the generated file.
 
+## How it works
+
+`WebhookController::checksum()` verifies the `X-Webhook-SHA1` header against the request body and the shop's license key. On success it initialises `ApiController` for that shop — ready to use via `getApiClient()`.
+
+## Example
+
+```php
 namespace App\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
 use PanKrok\ShoperAppstoreBundle\Controller\WebhookController as Webhook;
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
-class WebhookController extends AbstractController
+class OrderWebhookController extends AbstractController
 {
-    #[Route('/webhook', name: 'webhook')]
+    #[Route('/webhook/order', name: 'webhook_order')]
     public function index(Request $request, Webhook $webhook, LoggerInterface $logger): Response
     {
         try {
-            $webhook = $webhook->checksum($request, '12345')->getWebhookData();
-            // do stuff
-            
-            // get API client
+            $webhook->checksum($request, 'your-webhook-secret');
             $api = $webhook->getApiClient();
-            
-            return new Response(200);
+
+            // Your webhook logic here.
+            // Example: fetch the order that triggered the event.
+            // $data = json_decode($request->getContent(), true);
+            // $order = $api->order->get($data['object_id'])->getBodyArray();
+
+            return new Response('', Response::HTTP_OK);
+        } catch (ShoperApiException $e) {
+            $logger->error('Webhook API error: ' . $e->getMessage(), [
+                'error' => $e->getShoperError(),
+            ]);
+
+            return new Response('', Response::HTTP_INTERNAL_SERVER_ERROR);
         } catch (\Exception $e) {
-            $logger->error('Webhook Error: ' . $e->getMessage());
-            
-            return new Response(500);
+            $logger->error('Webhook error: ' . $e->getMessage());
+
+            return new Response('', Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 }
 ```
 
-You can obtain API Clinet from webhook service by method getApiClient():
+## Webhooks created directly in the store
+
+When a webhook is created in the shop admin panel (not via the Appstore), pass `false` as the third argument to skip the `X-Shop-License` header check:
+
 ```php
+$webhook->checksum($request, 'your-secret', false);
 $api = $webhook->getApiClient();
 ```
 
-If the webhook is generated directly in the store, false param should passed as in the example below:
+## Obtaining the API client
+
 ```php
-$webhook->checksum($request, '12345', false)->getWebhookData();
+$api = $webhook->getApiClient();
+
+// Use any resource
+$products = $api->product->get()->getBodyArray();
 ```

--- a/src/Command/TokenRefreshCommand.php
+++ b/src/Command/TokenRefreshCommand.php
@@ -2,68 +2,77 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Command;
 
+use Doctrine\Common\Collections\Criteria;
+use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
+use PanKrok\ShoperAppstoreBundle\Repository\AccessTokensRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use PanKrok\ShoperAppstoreBundle\Repository\AccessTokensRepository;
-use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[AsCommand(
-    name: 'ShoperAppstoreBundle:TokenRefresh',
-    description: 'This command automatickly refresh tokens',
+    name: 'shoper:token:refresh',
+    description: 'Refresh OAuth tokens that are close to expiry.',
+    aliases: ['ShoperAppstoreBundle:TokenRefresh'],
 )]
 class TokenRefreshCommand extends Command
 {
-
-    protected ApiController $api;
-    protected AccessTokensRepository $accessTokensRepository;
-    private $options;
-
-
-    public function __construct(ParameterBagInterface $container, ApiController $api, AccessTokensRepository $accessTokensRepository)
-    {
+    public function __construct(
+        private readonly ApiController $api,
+        private readonly AccessTokensRepository $accessTokensRepository,
+    ) {
         parent::__construct();
-        $this->api = $api;
-        $this->accessTokensRepository = $accessTokensRepository;
-        $this->options =$container->get('appstore');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum number of tokens to refresh per run.', 200)
+            ->addOption('hours-ahead', null, InputOption::VALUE_REQUIRED, 'Refresh tokens expiring within this many hours (max 23).', 23);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 
-        $output->write(json_encode($this->options));
+        $limit      = max(1, (int) $input->getOption('limit'));
+        $hoursAhead = min(23, max(1, (int) $input->getOption('hours-ahead')));
 
-        $date = new \DateTimeImmutable('now - 2days');
+        $threshold = new \DateTimeImmutable('@' . (time() + $hoursAhead * 3600));
 
-        $criteria = new \Doctrine\Common\Collections\Criteria();
-        $criteria->where($criteria->expr()->gt('expires_at', $date))
-            ->setMaxResults(100)
-        ;
+        $criteria = Criteria::create()
+            ->where(Criteria::expr()->lt('expiresAt', $threshold))
+            ->setMaxResults($limit);
 
         $tokens = $this->accessTokensRepository->matching($criteria);
 
-        if (count($tokens) > 0) {
-            $output->write('tokens found: ' . count($tokens) . PHP_EOL);
-            foreach ($tokens as $token) {
-                $shop = $token->getShop();
-                $output->write('shop found: ' . $shop->getShop() . PHP_EOL);
-                $params = ['shop' => $shop->getShop()];
-                $this->api->setParams($params, false);
-                sleep(1);
-            }
-        } else {
-            $output->write('no tokens found... ');
+        if (count($tokens) === 0) {
+            $io->success('No tokens need refreshing.');
+            return Command::SUCCESS;
         }
 
+        $io->note(sprintf('Found %d token(s) to refresh (threshold: %s).', count($tokens), $threshold->format('Y-m-d H:i:s')));
 
-        $io->success('Tokens updated');
+        $failed = 0;
+        foreach ($tokens as $token) {
+            $shop = $token->getShop();
+            try {
+                $this->api->refreshToken($shop);
+                $io->writeln(sprintf(' <info>✓</info> %s', $shop->getShop()));
+            } catch (\Throwable $e) {
+                $io->writeln(sprintf(' <error>✗</error> %s — %s', $shop->getShop(), $e->getMessage()));
+                ++$failed;
+            }
+        }
 
+        if ($failed > 0) {
+            $io->warning(sprintf('%d token(s) failed to refresh.', $failed));
+            return Command::FAILURE;
+        }
+
+        $io->success('All tokens refreshed successfully.');
         return Command::SUCCESS;
     }
 }

--- a/src/Controller/API/Client.php
+++ b/src/Controller/API/Client.php
@@ -57,7 +57,7 @@ class Client
         return $this->adapter;
     }
 
-    public static function setDefaultAdapter(ClientInterface $adapter)
+    public static function setDefaultAdapter(BearerInterface $adapter): void
     {
         self::$defaultAdapter = $adapter;
     }

--- a/src/Controller/API/Client/BasicAuth.php
+++ b/src/Controller/API/Client/BasicAuth.php
@@ -2,17 +2,19 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Controller\API\Client;
 
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
+
 class BasicAuth extends Bearer
 {
-    public function auth()
+    public function auth(): mixed
     {
         if (!isset($this->options['username']) || !isset($this->options['password'])) {
-            throw new \Exception('Shop api username and password must not be empty!');
+            throw new \InvalidArgumentException('Shop API username and password must not be empty.');
         }
-        
+
         $response = $this->client->request(
             'POST',
-            $this->entrypoint.'/webapi/rest/auth',
+            $this->entrypoint . '/webapi/rest/auth',
             [
                 'auth_basic' => [
                     'username' => $this->options['username'],
@@ -21,13 +23,21 @@ class BasicAuth extends Bearer
             ]
         );
 
+        if (200 !== $response->getStatusCode()) {
+            throw ShoperApiException::fromResponse(
+                $response->getStatusCode(),
+                $response->getContent(false)
+            );
+        }
+
         $token = $response->toArray();
         $this->setToken($token['access_token']);
 
         return $response;
     }
-    
-    public function refresh(string $code) {
-        throw new \Error('Not implemented');        
+
+    public function refresh(string $code = ''): never
+    {
+        throw new \BadMethodCallException('BasicAuth does not support token refresh.');
     }
 }

--- a/src/Controller/API/Client/Bearer.php
+++ b/src/Controller/API/Client/Bearer.php
@@ -2,6 +2,7 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Controller\API\Client;
 
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
 use PanKrok\ShoperAppstoreBundle\Model\ResponseModel;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpClient\Response\TraceableResponse;
@@ -49,8 +50,10 @@ class Bearer extends AbstractController implements BearerInterface
         );
 
         if (200 !== $this->response->getStatusCode()) {
-            $e = json_decode($this->response->getContent(false));
-            throw new \Exception($e->error."\r\n".$e->error_description, $this->response->getStatusCode());
+            throw ShoperApiException::fromResponse(
+                $this->response->getStatusCode(),
+                $this->response->getContent(false)
+            );
         }
 
         return new ResponseModel(

--- a/src/Controller/API/Client/Bearer.php
+++ b/src/Controller/API/Client/Bearer.php
@@ -2,27 +2,27 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Controller\API\Client;
 
+use PanKrok\ShoperAppstoreBundle\Controller\HttpClient;
 use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
 use PanKrok\ShoperAppstoreBundle\Model\ResponseModel;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpClient\Response\TraceableResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use PanKrok\ShoperAppstoreBundle\Controller\HttpClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class Bearer extends AbstractController implements BearerInterface
+class Bearer implements BearerInterface
 {
-    protected $client;
-    protected $entrypoint;
-    protected $token;
-    protected $refreshToken;
-    protected $expired;
-    protected $response = null;
+    protected HttpClientInterface $client;
+    protected string $entrypoint;
+    protected array $options = [];
+    protected ?string $token = null;
+    protected ?string $refreshToken = null;
+    protected ?int $expired = null;
+    protected ?ResponseInterface $response = null;
 
     public function __construct(array $options = [])
     {
-        $this->options = $options['options'];
+        $this->options    = $options['options'];
         $this->entrypoint = $options['entrypoint'];
-        $this->client = new HttpClient();
+        $this->client     = new HttpClient(\Symfony\Component\HttpClient\HttpClient::create());
     }
 
     public function setHttpClient(HttpClientInterface $client): void
@@ -37,7 +37,7 @@ class Bearer extends AbstractController implements BearerInterface
 
     public function setHttpClientOptions(array $options): void
     {
-        $this->client->withOptions($options);
+        $this->client = $this->client->withOptions($options);
     }
 
     public function request($request, $bulk = false): ResponseModel
@@ -45,7 +45,7 @@ class Bearer extends AbstractController implements BearerInterface
         $request['options']['auth_bearer'] = $this->getToken();
         $this->response = $this->client->request(
             $request['method'],
-            $this->entrypoint.'/webapi/rest/'.$request['url'],
+            $this->entrypoint . '/webapi/rest/' . $request['url'],
             $request['options']
         );
 
@@ -63,7 +63,7 @@ class Bearer extends AbstractController implements BearerInterface
         );
     }
 
-    public function getResponse(): TraceableResponse
+    public function getResponse(): ResponseInterface
     {
         return $this->response;
     }
@@ -77,7 +77,7 @@ class Bearer extends AbstractController implements BearerInterface
     {
         return $this->token;
     }
-    
+
     public function setRefreshToken(string $refreshToken): void
     {
         $this->refreshToken = $refreshToken;
@@ -87,25 +87,17 @@ class Bearer extends AbstractController implements BearerInterface
     {
         return $this->refreshToken;
     }
-    
-    
+
     public function isExpired(): bool
     {
-        if ($this->expired < time()) {
-            return true;
-        }
-        
-        return false;
+        return $this->expired < time();
     }
-    
-    public function isExpiredFromTimestamp(int $timestamp) {
-        if ($this->expired < $timestamp) {
-            return true;
-        }
-        
-        return false;
+
+    public function isExpiredFromTimestamp(int $timestamp): bool
+    {
+        return $this->expired < $timestamp;
     }
-    
+
     public function setExpired(int $time): void
     {
         $this->expired = $time;

--- a/src/Controller/API/Client/BearerInterface.php
+++ b/src/Controller/API/Client/BearerInterface.php
@@ -3,7 +3,7 @@
 namespace PanKrok\ShoperAppstoreBundle\Controller\API\Client;
 
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Component\HttpClient\Response\TraceableResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use PanKrok\ShoperAppstoreBundle\Model\ResponseModel;
 
 interface BearerInterface
@@ -12,7 +12,7 @@ interface BearerInterface
     public function getHttpClient(): HttpClientInterface;
     public function setHttpClientOptions(array $options): void;
     public function request($request, $bulk = false): ResponseModel;
-    public function getResponse(): TraceableResponse;
+    public function getResponse(): ResponseInterface;
     public function setToken(string $token): void;
     public function getToken(): ?string;
 }

--- a/src/Controller/API/Client/OAuth.php
+++ b/src/Controller/API/Client/OAuth.php
@@ -2,6 +2,8 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Controller\API\Client;
 
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
+
 class OAuth extends Bearer
 {
     protected const OAUTH_URL = '/webapi/rest/oauth/token?grant_type=authorization_code';
@@ -23,7 +25,10 @@ class OAuth extends Bearer
             ]
         );
         if (200 !== $response->getStatusCode()) {
-            throw new \Exception('Oauth exception: '.$response->getStatusCode()." \n".$response->getHeaders(false)." \n".$response->getContent(false)." \n");
+            throw ShoperApiException::fromResponse(
+                $response->getStatusCode(),
+                $response->getContent(false)
+            );
         }
 
         $token = $response->toArray();
@@ -47,11 +52,13 @@ class OAuth extends Bearer
                 ],
             ]
         );
-        // FIXME !
-        // if (200 !== $response->getStatusCode()) {
-            // throw new \Exception('Oauth refresh token exception: '.$response->getStatusCode()." \n".$response->getHeaders(false)." \n".$response->getContent(false)." \n");
-        // }
-        
+        if (200 !== $response->getStatusCode()) {
+            throw ShoperApiException::fromResponse(
+                $response->getStatusCode(),
+                $response->getContent(false)
+            );
+        }
+
         $token = $response->toArray();
         $this->setToken($token['access_token']);
 

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -2,154 +2,147 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Controller;
 
-use PanKrok\ShoperAppstoreBundle\Controller\API\Client;
-use PanKrok\ShoperAppstoreBundle\Repository\ShopsRepository;
-use PanKrok\ShoperAppstoreBundle\Entity\Shops;
-use PanKrok\ShoperAppstoreBundle\Controller\API\Client\BearerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use PanKrok\ShoperAppstoreBundle\Controller\API\Client;
+use PanKrok\ShoperAppstoreBundle\Controller\API\Client\BearerInterface;
+use PanKrok\ShoperAppstoreBundle\Entity\Shops;
+use PanKrok\ShoperAppstoreBundle\Repository\ShopsRepository;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class ApiController
 {
-    protected $client;
-    protected $apiOptions = [];
-    protected $params;
-    protected $shopUrl = null;
-    protected $shop = null;
-    protected $twig;
-    protected $em;
+    protected ?BearerInterface $client = null;
+    protected array $apiOptions = [];
+    protected array $requestParams = [];
+    protected ?string $shopUrl = null;
+    protected ?Shops $activeShop = null;
+    protected ShopsRepository $shopsRepository;
+    protected EntityManagerInterface $em;
 
-    public function __construct(ParameterBagInterface $container, ShopsRepository $shopsRepository, EntityManagerInterface $em)
-    {
+    public function __construct(
+        ParameterBagInterface $container,
+        ShopsRepository $shopsRepository,
+        EntityManagerInterface $em
+    ) {
         $this->apiOptions = $container->get('appstore');
         $this->shopsRepository = $shopsRepository;
+        $this->em = $em;
+
         if (isset($this->apiOptions['shopurl'])) {
             $this->shopUrl = $this->apiOptions['shopurl'];
         }
-        $this->em = $em;
     }
 
-    public function __get($property)
+    public function __get(string $property): mixed
     {
         $property = ucfirst($property);
-        if ($property === 'Bulk') {
-            $property .= 'Model';
-            $class = "\\PanKrok\\ShoperAppstoreBundle\\Model\\$property";
-        } else {
-            $class = "\\PanKrok\\ShoperAppstoreBundle\\Model\\Resource\\$property";
-        }
-        
+        $class = $property === 'Bulk'
+            ? "\\PanKrok\\ShoperAppstoreBundle\\Model\\BulkModel"
+            : "\\PanKrok\\ShoperAppstoreBundle\\Model\\Resource\\$property";
+
         if (class_exists($class)) {
-            return new $class($this->client);         
+            return new $class($this->client);
         }
+
+        return null;
     }
 
-    public function setParams(array $params, bool $checkHash = true): void
+    // -------------------------------------------------------------------------
+    // Current API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Initialise shop context from Shoper iframe query parameters.
+     * Verifies the HMAC hash by default, then sets up the OAuth client.
+     * Automatically refreshes the token if it expires within 24 hours.
+     */
+    public function initFromRequest(array $params, bool $checkHash = true): void
     {
-        
-        if (isset($params['shop'])) {
-            $this->params = $params;
-            if (false === $this->checkHash($checkHash)) {
-                throw new \Exception('Invalid hash');
-            }
+        if (!isset($params['shop'])) {
+            return;
+        }
 
-            $this->shop = $this->shopsRepository->findOneBy(['shop' => $params['shop']]);
-            $this->shopUrl = $this->shop->getShopUrl();
-            $token = $this->shop->getAccessTokens();
-        
-        
-            $options = [
-                'options' => $this->apiOptions,
-                'entrypoint' => $this->shopUrl,
-            ];
+        $this->requestParams = $params;
 
-            $this->client = Client::factory(Client::ADAPTER_OAUTH, $options);
-            $this->client->setToken($token->getAccessToken());
-            $this->client->setRefreshToken($token->getRefreshToken());
-            $this->client->setExpired($token->getExpiresAt()->getTimestamp());
-            
-            if ($this->client->isExpiredFromTimestamp(time() + (60*60*24 * 1))) {
-                $refreshedToken = $this->client->refresh();
-                $refreshedToken = $refreshedToken->toArray();
+        if (false === $this->verifyHash($checkHash)) {
+            throw new \Exception('Invalid hash');
+        }
 
-                $token->setExpiresAt(new \DateTimeImmutable('now + 30days'));
-                $token->setCreatedAt(new \DateTimeImmutable('now'));
-                $token->setAccessToken($refreshedToken['access_token']);
-                $token->setRefreshToken($refreshedToken['refresh_token']);
-                $this->em->flush($token);
-                
-                $this->client->setToken($token->getAccessToken());
-                $this->client->setRefreshToken($token->getRefreshToken());
-                $this->client->setExpired($token->getExpiresAt()->getTimestamp());
-            }
-        } 
-    }
+        $this->activeShop = $this->shopsRepository->findOneBy(['shop' => $params['shop']]);
+        $this->shopUrl = $this->activeShop->getShopUrl();
+        $token = $this->activeShop->getAccessTokens();
 
-    public function refreshShopToken(Shops $shop): void
-    {
-        $this->shopUrl = $shop->getShopUrl();
-        $token = $shop->getAccessTokens();
-        $options = [
-            'options' => $this->apiOptions,
+        $this->client = Client::factory(Client::ADAPTER_OAUTH, [
+            'options'    => $this->apiOptions,
             'entrypoint' => $this->shopUrl,
-        ];
-
-        $this->client = Client::factory(Client::ADAPTER_OAUTH, $options);
+        ]);
         $this->client->setToken($token->getAccessToken());
         $this->client->setRefreshToken($token->getRefreshToken());
         $this->client->setExpired($token->getExpiresAt()->getTimestamp());
-        
-        if ($this->client->isExpiredFromTimestamp(time() + (60*60*24 * 1))) {
-            $refreshedToken = $this->client->refresh();
-            $refreshedToken = $refreshedToken->toArray();
 
-            $token->setExpiresAt(new \DateTimeImmutable('now + 30days'));
-            $token->setCreatedAt(new \DateTimeImmutable('now'));
-            $token->setAccessToken($refreshedToken['access_token']);
-            $token->setRefreshToken($refreshedToken['refresh_token']);
-            $this->em->flush($token);
-            
-            $this->client->setToken($token->getAccessToken());
-            $this->client->setRefreshToken($token->getRefreshToken());
-            $this->client->setExpired($token->getExpiresAt()->getTimestamp());
+        if ($this->client->isExpiredFromTimestamp(time() + 60 * 60 * 24)) {
+            $this->performTokenRefresh($token);
         }
-
     }
-    
-    public function setBasicAuth(string $url = null, array $basicAuth = []): BearerInterface 
+
+    /**
+     * Refresh the OAuth token for a given shop.
+     * Used primarily by the CRON command.
+     */
+    public function refreshToken(Shops $shop): void
+    {
+        $this->shopUrl = $shop->getShopUrl();
+        $token = $shop->getAccessTokens();
+
+        $this->client = Client::factory(Client::ADAPTER_OAUTH, [
+            'options'    => $this->apiOptions,
+            'entrypoint' => $this->shopUrl,
+        ]);
+        $this->client->setToken($token->getAccessToken());
+        $this->client->setRefreshToken($token->getRefreshToken());
+        $this->client->setExpired($token->getExpiresAt()->getTimestamp());
+
+        if ($this->client->isExpiredFromTimestamp(time() + 60 * 60 * 24)) {
+            $this->performTokenRefresh($token);
+        }
+    }
+
+    /**
+     * Switch to Basic Auth (admin username/password) mode.
+     * Pass $url and $basicAuth to override YAML config values.
+     */
+    public function useBasicAuth(?string $url = null, array $basicAuth = []): BearerInterface
     {
         if (!empty($basicAuth)) {
             $this->apiOptions = $basicAuth;
         }
-        
-        if (isset($url)) {
+
+        if ($url !== null) {
             $this->shopUrl = $url;
         }
-        
-        $options = [
-            'options' =>$this->apiOptions,
-            'entrypoint' => $this->shopUrl,
-        ];
 
-        $this->client = Client::factory(Client::ADAPTER_BASIC_AUTH, $options);
+        $this->client = Client::factory(Client::ADAPTER_BASIC_AUTH, [
+            'options'    => $this->apiOptions,
+            'entrypoint' => $this->shopUrl,
+        ]);
+
         return $this->client;
     }
 
-    public function getParams()
+    public function getRequestParams(): array
     {
-        return $this->params;
+        return $this->requestParams;
     }
 
-     public function setClient(BearerInterface $client): void
+    public function setHttpClient(BearerInterface $client): void
     {
         $this->client = $client;
     }
 
-    public function getClient(): BearerInterface
+    public function getHttpClient(): BearerInterface
     {
         return $this->client;
     }
-    
 
     public function setShopUrl(string $url): void
     {
@@ -161,46 +154,152 @@ class ApiController
         return $this->shopUrl;
     }
 
-    public function setShop(Shops $shop)
+    public function bindShop(Shops $shop): void
     {
-        $this->setShopUrl($shop->getShopUrl());
-        $this->shop = $shop;
+        $this->shopUrl = $shop->getShopUrl();
+        $this->activeShop = $shop;
     }
 
-    public function getShop(): ?Shops
+    public function getActiveShop(): ?Shops
     {
-        return $this->shop;
+        return $this->activeShop;
     }
 
-    public function getAppId(): bool
+    /**
+     * Returns true when the bundle is configured for OAuth (Appstore) mode.
+     */
+    public function isOAuthMode(): bool
     {
         return isset($this->apiOptions['appId']);
     }
 
-    protected function checkHash(bool $checkHash): bool
+    // -------------------------------------------------------------------------
+    // Deprecated aliases — kept for backward compatibility
+    // -------------------------------------------------------------------------
+
+    /**
+     * @deprecated since 1.2.0, use initFromRequest() instead.
+     */
+    public function setParams(array $params, bool $checkHash = true): void
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use initFromRequest() instead.', E_USER_DEPRECATED);
+        $this->initFromRequest($params, $checkHash);
+    }
+
+    /**
+     * @deprecated since 1.2.0, use refreshToken() instead.
+     */
+    public function refreshShopToken(Shops $shop): void
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use refreshToken() instead.', E_USER_DEPRECATED);
+        $this->refreshToken($shop);
+    }
+
+    /**
+     * @deprecated since 1.2.0, use useBasicAuth() instead.
+     */
+    public function setBasicAuth(?string $url = null, array $basicAuth = []): BearerInterface
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use useBasicAuth() instead.', E_USER_DEPRECATED);
+        return $this->useBasicAuth($url, $basicAuth);
+    }
+
+    /**
+     * @deprecated since 1.2.0, use getRequestParams() instead.
+     */
+    public function getParams(): array
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use getRequestParams() instead.', E_USER_DEPRECATED);
+        return $this->getRequestParams();
+    }
+
+    /**
+     * @deprecated since 1.2.0, use setHttpClient() instead.
+     */
+    public function setClient(BearerInterface $client): void
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use setHttpClient() instead.', E_USER_DEPRECATED);
+        $this->setHttpClient($client);
+    }
+
+    /**
+     * @deprecated since 1.2.0, use getHttpClient() instead.
+     */
+    public function getClient(): BearerInterface
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use getHttpClient() instead.', E_USER_DEPRECATED);
+        return $this->getHttpClient();
+    }
+
+    /**
+     * @deprecated since 1.2.0, use bindShop() instead.
+     */
+    public function setShop(Shops $shop): void
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use bindShop() instead.', E_USER_DEPRECATED);
+        $this->bindShop($shop);
+    }
+
+    /**
+     * @deprecated since 1.2.0, use getActiveShop() instead.
+     */
+    public function getShop(): ?Shops
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use getActiveShop() instead.', E_USER_DEPRECATED);
+        return $this->getActiveShop();
+    }
+
+    /**
+     * @deprecated since 1.2.0, use isOAuthMode() instead.
+     */
+    public function getAppId(): bool
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use isOAuthMode() instead.', E_USER_DEPRECATED);
+        return $this->isOAuthMode();
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private function verifyHash(bool $checkHash): bool
     {
         if (false === $checkHash) {
             return true;
         }
 
         $params = [
-            'place' => $this->params['place'],
-            'shop' => $this->params['shop'],
-            'timestamp' => $this->params['timestamp'],
+            'place'     => $this->requestParams['place'],
+            'shop'      => $this->requestParams['shop'],
+            'timestamp' => $this->requestParams['timestamp'],
         ];
 
-        $send_hash = $this->params['hash'];
+        $sentHash = $this->requestParams['hash'];
         ksort($params);
-        $param_array = [];
+
+        $paramPairs = [];
         foreach ($params as $k => $v) {
-            $param_array[] = $k.'='.$v;
-        }
-        $param_string = join('&', $param_array);
-        $hash = hash_hmac('sha512', $param_string, $this->apiOptions['appstoreSecret']);
-        if ($hash === $send_hash) {
-            return true;
+            $paramPairs[] = $k . '=' . $v;
         }
 
-        return false;
+        $hash = hash_hmac('sha512', implode('&', $paramPairs), $this->apiOptions['appstoreSecret']);
+
+        return hash_equals($hash, $sentHash);
+    }
+
+    private function performTokenRefresh(object $token): void
+    {
+        $refreshed = $this->client->refresh()->toArray();
+
+        $expiresIn = isset($refreshed['expires_in']) ? (int) $refreshed['expires_in'] : 7776000;
+        $token->setExpiresAt(new \DateTimeImmutable('@' . (time() + $expiresIn)));
+        $token->setCreatedAt(new \DateTimeImmutable('now'));
+        $token->setAccessToken($refreshed['access_token']);
+        $token->setRefreshToken($refreshed['refresh_token']);
+        $this->em->flush($token);
+
+        $this->client->setToken($token->getAccessToken());
+        $this->client->setRefreshToken($token->getRefreshToken());
+        $this->client->setExpired($token->getExpiresAt()->getTimestamp());
     }
 }

--- a/src/Controller/AppstoreBillingController.php
+++ b/src/Controller/AppstoreBillingController.php
@@ -8,65 +8,61 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AppstoreBillingController
 {
-    protected $dispatcher;
-    protected $config;
+    protected EventDispatcherInterface $dispatcher;
+    protected array $config;
 
     public function __construct(EventDispatcherInterface $dispatcher, ParameterBagInterface $container)
     {
         $this->dispatcher = $dispatcher;
-        $this->config = $container->get('appstore');
+        $this->config     = $container->get('appstore');
     }
 
     public function init(array $request): Response
     {
         if (!isset($this->config['appstoreSecret'])) {
-            return new Response(400);
-        }
-        
-        if (true === self::checkHash($request, $this->config['appstoreSecret'])) {
-            $preEventName = '\\PanKrok\\ShoperAppstoreBundle\\Events\\Pre'.$this->camelCase($request['action']).'Event';
-            $eventName = '\\PanKrok\\ShoperAppstoreBundle\\Events\\'.$this->camelCase($request['action']).'Event';
-            if (class_exists($preEventName)) {
-                $preEvent = new $preEventName($request);
-                $this->dispatcher->dispatch($preEvent, $preEventName::NAME);
-            }
-
-            if (!class_exists($eventName)) {
-                throw new \Exception('Event for action "'.$request['action'].'" not found.');
-            }
-            
-            $event = new $eventName($request);
-            $this->dispatcher->dispatch($event, $eventName::NAME);
-
-            return new Response(200);
+            return new Response('', Response::HTTP_BAD_REQUEST);
         }
 
-        return new Response(403);
+        if (false === $this->checkHash($request, $this->config['appstoreSecret'])) {
+            return new Response('', Response::HTTP_FORBIDDEN);
+        }
+
+        $preEventName = '\\PanKrok\\ShoperAppstoreBundle\\Events\\Pre' . $this->camelCase($request['action']) . 'Event';
+        $eventName    = '\\PanKrok\\ShoperAppstoreBundle\\Events\\' . $this->camelCase($request['action']) . 'Event';
+
+        if (class_exists($preEventName)) {
+            $preEvent = new $preEventName($request);
+            $this->dispatcher->dispatch($preEvent, $preEventName::NAME);
+        }
+
+        if (!class_exists($eventName)) {
+            throw new \InvalidArgumentException('Event for action "' . $request['action'] . '" not found.');
+        }
+
+        $event = new $eventName($request);
+        $this->dispatcher->dispatch($event, $eventName::NAME);
+
+        return new Response('', Response::HTTP_OK);
     }
 
-    protected function checkHash(array $params, string $appstoreSecret): bool
+    private function checkHash(array $params, string $appstoreSecret): bool
     {
-        $send_hash = $params['hash'];
+        $sentHash = $params['hash'];
         unset($params['hash']);
         ksort($params);
-        $param_array = [];
+
+        $paramPairs = [];
         foreach ($params as $k => $v) {
-            $param_array[] = $k.'='.$v;
+            $paramPairs[] = $k . '=' . $v;
         }
 
-        $param_string = join('&', $param_array);
-        $hash = hash_hmac('sha512', $param_string, $appstoreSecret);
-        if ($send_hash === $hash) {
-            return true;
-        }
+        $hash = hash_hmac('sha512', implode('&', $paramPairs), $appstoreSecret);
 
-        return false;
+        return hash_equals($hash, $sentHash);
     }
 
-    protected function camelCase(string $string, bool $capitalizeFirstCharacter = true): string
+    private function camelCase(string $string): string
     {
-        $str = str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
-
-        return $str;
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
     }
 }

--- a/src/Controller/HttpClient.php
+++ b/src/Controller/HttpClient.php
@@ -13,14 +13,16 @@ class HttpClient implements HttpClientInterface
 {
     use AsyncDecoratorTrait;
 
-    protected $limit = 10;
-
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
         $passthru = function (ChunkInterface $chunk, AsyncContext $context) {
             yield $chunk;
+
             $headers = $context->getHeaders();
-            if ($headers['x-shop-api-calls'] === $headers['x-shop-api-limit']) {
+            $calls   = isset($headers['x-shop-api-calls'][0]) ? (int) $headers['x-shop-api-calls'][0] : null;
+            $limit   = isset($headers['x-shop-api-limit'][0]) ? (int) $headers['x-shop-api-limit'][0] : null;
+
+            if ($calls !== null && $limit !== null && $calls >= $limit) {
                 sleep(1);
             }
         };

--- a/src/Controller/WebhookController.php
+++ b/src/Controller/WebhookController.php
@@ -37,7 +37,7 @@ class WebhookController
         }
 
         $this->api = new ApiController($this->container, $this->shopRepository, $this->em);
-        $this->api->setParams(['shop' => $server['HTTP_X_SHOP_LICENSE']], false);
+        $this->api->initFromRequest(['shop' => $server['HTTP_X_SHOP_LICENSE']], false);
 
         return $request;
     }

--- a/src/Entity/AccessTokens.php
+++ b/src/Entity/AccessTokens.php
@@ -25,12 +25,12 @@ class AccessTokens
     #[ORM\Column(length: 64)]
     private ?string $refresh_token = null;
 
-    #[ORM\OneToOne(inversedBy: 'accessTokens', cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(inversedBy: 'accessTokens', cascade: ['persist'])]
     private ?Shops $shop = null;
 
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->id;
+        return (string) $this->id;
     }
 
     public function getId(): ?int

--- a/src/EventSubscriber/BillingInstallSubscriber.php
+++ b/src/EventSubscriber/BillingInstallSubscriber.php
@@ -27,7 +27,7 @@ class BillingInstallSubscriber implements EventSubscriberInterface
 
     public function onBillingInstall($event)
     {
-        $eventName = '\\PanKrok\\ShoperAppstoreBundle\\EventListener\\PostBillingInstallEvent';
+        $eventName = '\\PanKrok\\ShoperAppstoreBundle\\Events\\PostBillingInstallEvent';
         $payload = $event->getPayload();
         if (($shop = $this->shopsRepository->findOneBy(['shop' => $payload['shop']])) !== null) {
             $billing = new Billings();

--- a/src/EventSubscriber/ExceptionSubscriber.php
+++ b/src/EventSubscriber/ExceptionSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PanKrok\ShoperAppstoreBundle\EventSubscriber;
+
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig\Environment;
+
+class ExceptionSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly Environment $twig)
+    {
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if (!$exception instanceof ShoperApiException) {
+            return;
+        }
+
+        $html = $this->twig->render('@Appstore/error.html.twig', [
+            'status_code'       => $exception->getStatusCode(),
+            'error'             => $exception->getShoperError(),
+            'error_description' => $exception->getShoperErrorDescription(),
+        ]);
+
+        $event->setResponse(new Response($html, $exception->getStatusCode()));
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', 10],
+        ];
+    }
+}

--- a/src/EventSubscriber/InstallSubscriber.php
+++ b/src/EventSubscriber/InstallSubscriber.php
@@ -47,12 +47,13 @@ class InstallSubscriber implements EventSubscriberInterface
         }
 
         if (($shop = $this->shopsRepository->findOneBy(['shop' => $payload['shop']])) !== null) {
-            if (($token = $shop->getAccessTokens()) !== null) {
-                $this->em->remove($token);
-                $this->em->flush();
+            if (($existingToken = $shop->getAccessTokens()) !== null) {
+                $this->em->remove($existingToken);
             }
 
             $shop->setInstalled(true);
+            $shop->setShopUrl($payload['shop_url']);
+            $shop->setVersion($payload['application_version']);
         } else {
             $shop = new Shops();
             $shop->setInstalled(true);
@@ -62,16 +63,17 @@ class InstallSubscriber implements EventSubscriberInterface
             $shop->setVersion($payload['application_version']);
         }
 
-        $this->em->persist($shop);
-        $this->em->flush();
+        $expiresIn = isset($response['expires_in']) ? (int) $response['expires_in'] : 7776000;
+        $expiresAt = new \DatetimeImmutable('@' . (time() + $expiresIn));
 
         $token = new AccessTokens();
         $token->setShop($shop);
-        $token->setExpiresAt(new \DatetimeImmutable('now + 30days'));
+        $token->setExpiresAt($expiresAt);
         $token->setCreatedAt(new \DatetimeImmutable('now'));
         $token->setAccessToken($response['access_token']);
         $token->setRefreshToken($response['refresh_token']);
 
+        $this->em->persist($shop);
         $this->em->persist($token);
         $this->em->flush();
 

--- a/src/EventSubscriber/RequestSubscriber.php
+++ b/src/EventSubscriber/RequestSubscriber.php
@@ -20,8 +20,8 @@ class RequestSubscriber implements EventSubscriberInterface
         if ($event->getRequest()->attributes->has('_route')) {
             $query = $event->getRequest()->query->all();
             $routeName = $event->getRequest()->attributes->get('_route');
-            if (strpos($routeName, 'billing_') === false && $this->api->getAppId() === true) {
-                $this->api->setParams($query);
+            if (strpos($routeName, 'billing_') === false && $this->api->isOAuthMode() === true) {
+                $this->api->initFromRequest($query);
             }
         }
     }

--- a/src/EventSubscriber/UninstallSubscriber.php
+++ b/src/EventSubscriber/UninstallSubscriber.php
@@ -26,10 +26,8 @@ class UninstallSubscriber implements EventSubscriberInterface
         if (($shop = $this->shopsRepository->findOneBy(['shop' => $payload['shop']])) !== null) {
             if (($token = $shop->getAccessTokens()) !== null) {
                 $this->em->remove($token);
-                $this->em->flush();
             }
 
-            $shop->setAccessTokens(null);
             $shop->setInstalled(false);
             $this->em->persist($shop);
             $this->em->flush();

--- a/src/EventSubscriber/UpgradeSubscriber.php
+++ b/src/EventSubscriber/UpgradeSubscriber.php
@@ -3,67 +3,36 @@
 namespace PanKrok\ShoperAppstoreBundle\EventSubscriber;
 
 use Doctrine\ORM\EntityManagerInterface;
-use PanKrok\ShoperAppstoreBundle\Controller\API\Client;
-use PanKrok\ShoperAppstoreBundle\Entity\AccessTokens;
 use PanKrok\ShoperAppstoreBundle\Events\UpgradeEvent;
 use PanKrok\ShoperAppstoreBundle\Repository\ShopsRepository;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class UpgradeSubscriber implements EventSubscriberInterface
 {
-    protected $client;
     protected $em;
-    protected $tokensEntity;
     protected $shopsRepository;
 
     public function __construct(
         EntityManagerInterface $entityManager,
-        ParameterBagInterface $container,
         ShopsRepository $shopsRepository,
     ) {
         $this->em = $entityManager;
-        $this->config = $container->get('appstore');
         $this->shopsRepository = $shopsRepository;
     }
 
     public function onUpgradeAction($event)
     {
         $payload = $event->getPayload();
-        $options = [
-            'appstore' => $this->config,
-            'entrypoint' => $payload['shop_url'],
-        ];
 
-        $this->client = Client::factory(Client::ADAPTER_OAUTH, $options);
-        $response = $this->client->auth($payload['auth_code'])->toArray();
-        if (!isset($response['access_token'])) {
-            throw new \Exception('Can\'t obtain access token');
+        $shop = $this->shopsRepository->findOneBy(['shop' => $payload['shop']]);
+        if ($shop === null) {
+            throw new \Exception('UpgradeSubscriber error: shop not found');
         }
 
-        if (($shop = $this->shopsRepository->findOneBy(['shop' => $payload['shop']])) !== null) {
-            if (($token = $shop->getAccessTokens()) !== null) {
-                $this->em->remove($token);
-                $this->em->flush();
-            }
-
-            $shop->setInstalled(true);
-        } else {
-            throw new \Exception('InstallSubscriber error: shop not found');
-        }
+        $shop->setVersion($payload['application_version']);
+        $shop->setShopUrl($payload['shop_url']);
 
         $this->em->persist($shop);
-        $this->em->flush();
-
-        $token = new AccessTokens();
-        $token->setShop($shop);
-        $token->setExpiresAt(new \DatetimeImmutable('now + 30days'));
-        $token->setCreatedAt(new \DatetimeImmutable('now'));
-        $token->setAccessToken($response['access_token']);
-        $token->setRefreshToken($response['refresh_token']);
-
-        $this->em->persist($token);
         $this->em->flush();
     }
 

--- a/src/Events/PostBillingInstallEvent.php
+++ b/src/Events/PostBillingInstallEvent.php
@@ -15,7 +15,7 @@ class PostBillingInstallEvent extends Event
         $this->shop = $shop;
     }
 
-    public function getShop(): Shop
+    public function getShop(): Shops
     {
         return $this->shop;
     }

--- a/src/Exception/ShoperApiException.php
+++ b/src/Exception/ShoperApiException.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace PanKrok\ShoperAppstoreBundle\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ShoperApiException extends HttpException
+{
+    private string $shoperError;
+    private string $shoperErrorDescription;
+    private ?string $rawResponse;
+
+    public function __construct(
+        int $statusCode,
+        string $shoperError = '',
+        string $shoperErrorDescription = '',
+        ?string $rawResponse = null,
+        ?\Throwable $previous = null,
+        array $headers = []
+    ) {
+        $this->shoperError = $shoperError;
+        $this->shoperErrorDescription = $shoperErrorDescription;
+        $this->rawResponse = $rawResponse;
+
+        $message = $shoperError;
+        if ($shoperErrorDescription) {
+            $message .= ': ' . $shoperErrorDescription;
+        }
+
+        parent::__construct($statusCode, $message, $previous, $headers);
+    }
+
+    public static function fromResponse(int $statusCode, string $responseBody, ?\Throwable $previous = null): self
+    {
+        $data = json_decode($responseBody, true);
+
+        $error = $data['error'] ?? 'api_error';
+        $errorDescription = $data['error_description'] ?? $responseBody;
+
+        return new self($statusCode, $error, $errorDescription, $responseBody, $previous);
+    }
+
+    public function getShoperError(): string
+    {
+        return $this->shoperError;
+    }
+
+    public function getShoperErrorDescription(): string
+    {
+        return $this->shoperErrorDescription;
+    }
+
+    public function getRawResponse(): ?string
+    {
+        return $this->rawResponse;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'error' => $this->shoperError,
+            'error_description' => $this->shoperErrorDescription,
+            'status_code' => $this->getStatusCode(),
+        ];
+    }
+}

--- a/src/Maker/MakeShoperBillingController.php
+++ b/src/Maker/MakeShoperBillingController.php
@@ -2,24 +2,15 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Maker;
 
-use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
-use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
-use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
-
 
 final class MakeShoperBillingController extends AbstractMaker
 {
@@ -30,18 +21,21 @@ final class MakeShoperBillingController extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new Shopper appstore billing controller class';
+        return 'Creates a new Shoper appstore billing controller class';
     }
 
-    public function configureCommand(Command $command, InputConfiguration $inputConf)
+    public function configureCommand(Command $command, InputConfiguration $inputConf): void
     {
         $command
-            ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your billing controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
-            ->setHelp(file_get_contents(__DIR__.'/controller/MakeShoperBillingController.txt'))
-        ;
+            ->addArgument(
+                'controller-class',
+                InputArgument::OPTIONAL,
+                sprintf('Choose a name for your billing controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm()))
+            )
+            ->setHelp(file_get_contents(__DIR__ . '/controller/MakeShoperBillingController.txt'));
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $controllerClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('controller-class'),
@@ -49,26 +43,22 @@ final class MakeShoperBillingController extends AbstractMaker
             'Controller'
         );
 
-        $controllerPath = $generator->generateController(
+        $generator->generateController(
             $controllerClassNameDetails->getFullName(),
-            __DIR__.'/controller/BillingControllerShoper.tpl.php',
+            __DIR__ . '/controller/BillingControllerShoper.tpl.php',
             [
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'route_name' => 'billing_'.Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
+                'route_name' => 'billing_' . Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
             ]
         );
 
         $generator->writeChanges();
 
         $this->writeSuccessMessage($io);
-        $io->text('Your billing controller is ready under route: '.Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()));
+        $io->text('Your billing controller is ready under route: ' . Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()));
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public function configureDependencies(DependencyBuilder $dependencies): void
     {
-        // $dependencies->addClassDependency(
-        //     Annotation::class,
-        //     'doctrine/annotations'
-        // );
     }
 }

--- a/src/Maker/MakeShoperController.php
+++ b/src/Maker/MakeShoperController.php
@@ -2,23 +2,17 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Maker;
 
-use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
-use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 
 final class MakeShoperController extends AbstractMaker
 {
@@ -29,19 +23,22 @@ final class MakeShoperController extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new Shopper appstore controller class';
+        return 'Creates a new Shoper appstore controller class';
     }
 
-    public function configureCommand(Command $command, InputConfiguration $inputConf)
+    public function configureCommand(Command $command, InputConfiguration $inputConf): void
     {
         $command
-            ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addArgument(
+                'controller-class',
+                InputArgument::OPTIONAL,
+                sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm()))
+            )
             ->addOption('no-template', null, InputOption::VALUE_NONE, 'Use this option to disable template generation')
-            ->setHelp(file_get_contents(__DIR__.'/controller/MakeShoperController.txt'))
-        ;
+            ->setHelp(file_get_contents(__DIR__ . '/controller/MakeShoperController.txt'));
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $controllerClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('controller-class'),
@@ -49,27 +46,29 @@ final class MakeShoperController extends AbstractMaker
             'Controller'
         );
 
-        $noTemplate = $input->getOption('no-template');
-        $templateName = Str::asFilePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()).'/index.html.twig';
+        $noTemplate   = $input->getOption('no-template');
+        $templateName = Str::asFilePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()) . '/index.html.twig';
+
         $controllerPath = $generator->generateController(
             $controllerClassNameDetails->getFullName(),
-            __DIR__.'/controller/ControllerShoper.tpl.php',
+            __DIR__ . '/controller/ControllerShoper.tpl.php',
             [
-                'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
+                'route_path'    => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
+                'route_name'    => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'with_template' => $this->isTwigInstalled() && !$noTemplate,
                 'template_name' => $templateName,
+                'controller_path' => 'src/Controller/' . $controllerClassNameDetails->getShortName() . '.php',
             ]
         );
 
         if ($this->isTwigInstalled() && !$noTemplate) {
             $generator->generateTemplate(
                 $templateName,
-                __DIR__.'/controller/twig_shoper_template.tpl.php',
+                __DIR__ . '/controller/twig_shoper_template.tpl.php',
                 [
                     'controller_path' => $controllerPath,
-                    'root_directory' => $generator->getRootDirectory(),
-                    'class_name' => $controllerClassNameDetails->getShortName(),
+                    'root_directory'  => $generator->getRootDirectory(),
+                    'class_name'      => $controllerClassNameDetails->getShortName(),
                 ]
             );
         }
@@ -80,11 +79,11 @@ final class MakeShoperController extends AbstractMaker
         $io->text('Next: Open your new controller class and add some pages!');
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public function configureDependencies(DependencyBuilder $dependencies): void
     {
     }
 
-    private function isTwigInstalled()
+    private function isTwigInstalled(): bool
     {
         return class_exists(TwigBundle::class);
     }

--- a/src/Maker/MakeShoperWebhookController.php
+++ b/src/Maker/MakeShoperWebhookController.php
@@ -2,23 +2,16 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Maker;
 
-use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
-use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
-use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 
 final class MakeShoperWebhookController extends AbstractMaker
 {
@@ -29,34 +22,46 @@ final class MakeShoperWebhookController extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new Shopper appstore webhook controller class';
+        return 'Creates a new Shoper appstore webhook controller class';
     }
 
-    public function configureCommand(Command $command, InputConfiguration $inputConf)
+    public function configureCommand(Command $command, InputConfiguration $inputConf): void
     {
         $command
-            ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
-            ->addOption('secret', null, InputOption::VALUE_NONE, 'Set secret of your webhook')
-            ->setHelp(file_get_contents(__DIR__.'/controller/MakeShoperWebhookController.txt'))
-        ;
+            ->addArgument(
+                'controller-class',
+                InputArgument::OPTIONAL,
+                sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm()))
+            )
+            ->addOption('secret', null, InputOption::VALUE_OPTIONAL, 'Webhook secret for checksum verification', '')
+            ->setHelp(file_get_contents(__DIR__ . '/controller/MakeShoperWebhookController.txt'));
 
         $inputConf->setArgumentAsNonInteractive('controller-class');
     }
 
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
         if (!$input->getArgument('controller-class')) {
-            $controllerClass = $io->ask('Enter a class name of your webhook controller', 'string', [Validator::class, 'notBlank']);
+            $controllerClass = $io->ask(
+                'Enter a class name of your webhook controller',
+                null,
+                static function (?string $value): string {
+                    if (empty($value)) {
+                        throw new \RuntimeException('The controller class name cannot be empty.');
+                    }
+                    return $value;
+                }
+            );
             $input->setArgument('controller-class', $controllerClass);
         }
 
         if (!$input->getOption('secret')) {
-            $secret = $io->ask('Enter a secret of your webhook', 'string', [Validator::class, 'notBlank']);
-            $input->setOption('secret', $secret);
+            $secret = $io->ask('Enter webhook secret (leave empty to configure later)', '');
+            $input->setOption('secret', $secret ?? '');
         }
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $controllerClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('controller-class'),
@@ -64,33 +69,28 @@ final class MakeShoperWebhookController extends AbstractMaker
             'Controller'
         );
 
-        $secret = $input->getOption('secret');
+        $secret = $input->getOption('secret') ?? '';
 
-        $controllerPath = $generator->generateController(
+        $generator->generateController(
             $controllerClassNameDetails->getFullName(),
-            __DIR__.'/controller/WebhookControllerShoper.tpl.php',
+            __DIR__ . '/controller/WebhookControllerShoper.tpl.php',
             [
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'secret' => $secret,
+                'secret'     => $secret,
             ]
         );
 
         $generator->writeChanges();
 
         $this->writeSuccessMessage($io);
-        $io->text('Next: Open your new controller class and add some logic!');
+        $io->text('Next: Open your new controller class and add webhook logic!');
+        if (empty($secret)) {
+            $io->note('Remember to configure the webhook secret in your controller.');
+        }
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public function configureDependencies(DependencyBuilder $dependencies): void
     {
-
-    }
-
-    protected function question(Command $command)
-    {
-        $question = new Question('Please enter the secret of the Shoper webhook', '');
-        $helper = $command->getHelper('question');
-        $secret = $helper->ask($input, $output, $question);
     }
 }

--- a/src/Maker/controller/BillingControllerShoper.tpl.php
+++ b/src/Maker/controller/BillingControllerShoper.tpl.php
@@ -2,11 +2,11 @@
 
 namespace <?php echo $namespace; ?>;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
 use PanKrok\ShoperAppstoreBundle\Controller\AppstoreBillingController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
 class <?php echo $class_name; ?> extends AbstractController
 {

--- a/src/Maker/controller/ControllerShoper.tpl.php
+++ b/src/Maker/controller/ControllerShoper.tpl.php
@@ -2,26 +2,30 @@
 
 namespace <?php echo $namespace; ?>;
 
+use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
-use PanKrok\ShoperAppstoreBundle\Controller\ApiController;
+use Symfony\Component\Routing\Attribute\Route;
 
 class <?php echo $class_name; ?> extends AbstractController
 {
 <?php echo $generator->generateRouteForControllerMethod($route_path, $route_name); ?>
     public function index(ApiController $api): Response
     {
+        try {
 <?php if ($with_template) { ?>
-        return $this->render('<?php echo $template_name; ?>', [
-            'controller_name' => '<?php echo $class_name; ?>',
-        ]);
+            return $this->render('<?php echo $template_name; ?>', [
+                'controller_name' => '<?php echo $class_name; ?>',
+            ]);
 <?php } else { ?>
-        return $this->json([
-            'message' => 'Welcome to your new controller!',
-            'path' => '<?php echo $relative_path; ?>',
-        ]);
+            return $this->json([
+                'message' => 'Welcome to your new controller!',
+                'path' => '<?php echo $controller_path; ?>',
+            ]);
 <?php } ?>
+        } catch (ShoperApiException $e) {
+            throw $e;
+        }
     }
 }

--- a/src/Maker/controller/WebhookControllerShoper.tpl.php
+++ b/src/Maker/controller/WebhookControllerShoper.tpl.php
@@ -2,12 +2,13 @@
 
 namespace <?php echo $namespace; ?>;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
 use PanKrok\ShoperAppstoreBundle\Controller\WebhookController;
+use PanKrok\ShoperAppstoreBundle\Exception\ShoperApiException;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
 class <?php echo $class_name; ?> extends AbstractController
 {
@@ -15,13 +16,21 @@ class <?php echo $class_name; ?> extends AbstractController
     public function index(Request $request, WebhookController $webhook, LoggerInterface $logger): Response
     {
         try {
-            $webhook = $webhook->checksum($request, '<?php echo $secret; ?>')->toArray();
-            
-            return new Response(200);
+            $webhook->checksum($request, '<?php echo $secret; ?>');
+            $api = $webhook->getApiClient();
+
+            // Your webhook logic here.
+            // Example: $products = $api->product->get()->getBodyArray();
+
+            return new Response('', Response::HTTP_OK);
+        } catch (ShoperApiException $e) {
+            $logger->error('Webhook API error: ' . $e->getMessage(), ['error' => $e->getShoperError()]);
+
+            return new Response('', Response::HTTP_INTERNAL_SERVER_ERROR);
         } catch (\Exception $e) {
-            $logger->error('Webhook Error: ' . $e->getMessage());
-            
-            return new Response(500);
+            $logger->error('Webhook error: ' . $e->getMessage());
+
+            return new Response('', Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/Maker/controller/twig_shoper_template.tpl.php
+++ b/src/Maker/controller/twig_shoper_template.tpl.php
@@ -1,21 +1,18 @@
 <?php echo $helper->getHeadPrintCode("Hello $class_name!"); ?>
 
 {% block body %}
-
- <div class="container">
-	<div class="row">
-		<div class="col_grow">
-			<div class="box box_spacing box_primary mt-2">
-                <h1>Hello {{ controller_name }}! ✅</h1>
-				This friendly message is coming from:
+<div class="container">
+    <div class="row">
+        <div class="col_grow">
+            <div class="box box_spacing box_primary mt-2">
+                <h1>Hello {{ controller_name }}!</h1>
+                This friendly message is coming from:
                 <ul class="list">
                     <li>Your controller at <code><?php echo $helper->getFileLink("$root_directory/$controller_path", "$controller_path"); ?></code></li>
                     <li>Your template at <code><?php echo $helper->getFileLink("$root_directory/$relative_path", "$relative_path"); ?></code></li>
                 </ul>
-			</div>
-		</div>
-	</div>
-</div>
-    
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/src/Model/BulkModel.php
+++ b/src/Model/BulkModel.php
@@ -58,10 +58,10 @@ final class BulkModel extends RequestModel
         return $this;
     }
 
-    public function send()
+    public function send(): ResponseModel
     {
-        $request = $this->prepareRequest('POST');
-        $this->body = null;
+        $request    = $this->prepareRequest('POST');
+        $this->body = [];
 
         return $this->client->request($request, true);
     }

--- a/src/Model/RequestModel.php
+++ b/src/Model/RequestModel.php
@@ -6,22 +6,23 @@ use PanKrok\ShoperAppstoreBundle\Controller\API\Client\BearerInterface;
 
 class RequestModel
 {
-    protected $client;
-    protected $bulk;
-    protected $body = [];
-    protected $filters = null;
-    protected $order = null;
-    protected $limit = 20;
-    protected $page = 0;
-    protected $method = null;
+    protected BearerInterface $client;
+    protected mixed $bulk = false;
+    protected array $body = [];
+    protected ?string $filters = null;
+    protected ?array $order = null;
+    protected int $limit = 20;
+    protected int $page = 0;
+    protected ?string $method = null;
+    protected string $url = '';
 
-    public function __construct(BearerInterface $client, $bulk = false)
+    public function __construct(BearerInterface $client, mixed $bulk = false)
     {
         $this->client = $client;
-        $this->bulk = $bulk;
+        $this->bulk   = $bulk;
     }
 
-    public function setBody(array $body): RequestModel
+    public function setBody(array $body): static
     {
         $this->body = $body;
 
@@ -33,39 +34,48 @@ class RequestModel
         return $this->body;
     }
 
-    public function getClinet(): BearerInterface
+    public function getClient(): BearerInterface
     {
         return $this->client;
     }
 
-    protected function prepareBulk($method): array
+    /**
+     * @deprecated since 1.2.0, use getClient() instead.
+     */
+    public function getClinet(): BearerInterface
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use getClient() instead.', E_USER_DEPRECATED);
+        return $this->getClient();
+    }
+
+    protected function prepareBulk(string $method): array
     {
         return [
             'method' => $method,
-            'path' => '/webapi/rest/'.$this->url,
-            'params' => ([
-                'page' => $this->page,
-                'limit' => $this->limit,
+            'path'   => '/webapi/rest/' . $this->url,
+            'params' => array_filter([
+                'page'    => $this->page,
+                'limit'   => $this->limit,
                 'filters' => $this->filters,
-                'order' => $this->order,
-            ]),
-            'body' => $this->body,
+                'order'   => $this->order,
+            ], fn($v) => $v !== null),
+            'body'   => $this->body,
         ];
     }
 
-    protected function prepareRequest($method): array
+    protected function prepareRequest(string $method, ?string $urlOverride = null): array
     {
         return [
-            'method' => $method,
-            'url' => $this->url,
+            'method'  => $method,
+            'url'     => $urlOverride ?? $this->url,
             'options' => [
-                'query' => [
-                    'page' => $this->page,
-                    'limit' => $this->limit,
+                'query' => array_filter([
+                    'page'    => $this->page,
+                    'limit'   => $this->limit,
                     'filters' => $this->filters,
-                    'order' => $this->order,
-                ],
-                'json' => $this->body,
+                    'order'   => $this->order,
+                ], fn($v) => $v !== null),
+                'json'  => $this->body,
             ],
         ];
     }

--- a/src/Model/ResourceInterface.php
+++ b/src/Model/ResourceInterface.php
@@ -4,15 +4,16 @@ namespace PanKrok\ShoperAppstoreBundle\Model;
 
 interface ResourceInterface
 {
-    public function setFilters(array $filters): ResourceModel;
+    public function setFilters(array $filters): static;
     public function getFilters(): array;
-    public function setOrder(string $order): ResourceModel;
+    public function setOrder(string $order): static;
     public function getOrder(): array;
+    public function setLimit(int $limit): static;
     public function getLimit(): int;
-    public function setPage(int $page): ResourceModel;
+    public function setPage(int $page): static;
     public function getPage(): int;
     public function get(array|int|null $body = null): ResponseModel|array;
     public function post(array $body = []): ResponseModel|array;
     public function put(int $id, array $body): ResponseModel|array;
-    public function delete(array|int $body): ResponseModel|array;    
+    public function delete(array|int $body): ResponseModel|array;
 }

--- a/src/Model/ResourceModel.php
+++ b/src/Model/ResourceModel.php
@@ -2,11 +2,11 @@
 
 namespace PanKrok\ShoperAppstoreBundle\Model;
 
-use PanKrok\ShoperAppstoreBundle\Model\ResponseModel;
-
 class ResourceModel extends RequestModel implements ResourceInterface
 {
-    public function setFilters(array $filters): ResourceModel
+    public const MAX_LIMIT = 50;
+
+    public function setFilters(array $filters): static
     {
         $this->filters = json_encode($filters);
 
@@ -15,31 +15,30 @@ class ResourceModel extends RequestModel implements ResourceInterface
 
     public function getFilters(): array
     {
-        return json_decode($this->filters, true);
+        if ($this->filters === null) {
+            return [];
+        }
+
+        return json_decode($this->filters, true) ?? [];
     }
 
-    public function setOrder(string $order): ResourceModel
+    public function setOrder(string $order): static
     {
-        $matches = [];
-        $expr = (array) $order;
+        $expr   = (array) $order;
         $result = [];
 
         foreach ($expr as $e) {
-            // basic syntax, with asc/desc suffix
             if (preg_match('/([a-z_0-9.]+) (asc|desc)$/i', $e)) {
                 $result[] = $e;
             } elseif (preg_match('/([\+\-]?)([a-z_0-9.]+)/i', $e, $matches)) {
                 $subResult = $matches[2];
-                if ('' == $matches[1] || '+' == $matches[1]) {
-                    $subResult .= ' asc';
-                } else {
-                    $subResult .= ' desc';
-                }
-                $result[] = $subResult;
+                $subResult .= ('' === $matches[1] || '+' === $matches[1]) ? ' asc' : ' desc';
+                $result[]   = $subResult;
             } else {
-                throw new \Exception('Cannot understand ordering expression');
+                throw new \InvalidArgumentException('Cannot understand ordering expression: "' . $e . '"');
             }
         }
+
         $this->order = $result;
 
         return $this;
@@ -47,13 +46,15 @@ class ResourceModel extends RequestModel implements ResourceInterface
 
     public function getOrder(): array
     {
-        return $this->order;
+        return $this->order ?? [];
     }
 
-    public function setLimit(int $limit): ResourceModel
+    public function setLimit(int $limit): static
     {
-        if ($limit < 1 || $limit > 50) {
-            throw new \Exception('Limit beyond 1-50 range');
+        if ($limit < 1 || $limit > self::MAX_LIMIT) {
+            throw new \InvalidArgumentException(
+                sprintf('Limit must be between 1 and %d, got %d.', self::MAX_LIMIT, $limit)
+            );
         }
         $this->limit = $limit;
 
@@ -65,10 +66,10 @@ class ResourceModel extends RequestModel implements ResourceInterface
         return $this->limit;
     }
 
-    public function setPage(int $page): ResourceModel
+    public function setPage(int $page): static
     {
         if ($page < 0) {
-            throw new \Exception('Page parameter must be positive');
+            throw new \InvalidArgumentException('Page parameter must be a non-negative integer.');
         }
         $this->page = $page;
 
@@ -86,16 +87,13 @@ class ResourceModel extends RequestModel implements ResourceInterface
             $this->setBody($body);
         }
 
-        if (is_int($body)) {
-            $this->url .= '/'.$body;
-        }
+        $url = is_int($body) ? $this->url . '/' . $body : $this->url;
 
         if ($this->bulk) {
             return $this->prepareBulk('GET');
         }
 
-        $request = $this->prepareRequest('GET');
-        return $this->client->request($request);
+        return $this->client->request($this->prepareRequest('GET', $url));
     }
 
     public function post(array $body = []): ResponseModel|array
@@ -107,14 +105,13 @@ class ResourceModel extends RequestModel implements ResourceInterface
         if ($this->bulk) {
             return $this->prepareBulk('POST');
         }
-        
-        if(isset($this->object) && $this->url === 'metafields') {
-            $this->url .= '/'.$this->object;
+
+        if (isset($this->object) && $this->url === 'metafields') {
+            $url = $this->url . '/' . $this->object;
+            return $this->client->request($this->prepareRequest('POST', $url));
         }
 
-        $request = $this->prepareRequest('POST');
-
-        return $this->client->request($request);
+        return $this->client->request($this->prepareRequest('POST'));
     }
 
     public function put(int $id, array $body): ResponseModel|array
@@ -122,15 +119,14 @@ class ResourceModel extends RequestModel implements ResourceInterface
         if (!empty($body)) {
             $this->setBody($body);
         }
-        $this->url .= '/'.$id;
+
+        $url = $this->url . '/' . $id;
 
         if ($this->bulk) {
             return $this->prepareBulk('PUT');
         }
 
-        $request = $this->prepareRequest('PUT');
-
-        return $this->client->request($request);
+        return $this->client->request($this->prepareRequest('PUT', $url));
     }
 
     public function delete(array|int $body): ResponseModel|array
@@ -139,16 +135,12 @@ class ResourceModel extends RequestModel implements ResourceInterface
             $this->setBody($body);
         }
 
-        if (is_int($body)) {
-            $this->url .= '/'.$body;
-        }
+        $url = is_int($body) ? $this->url . '/' . $body : $this->url;
 
         if ($this->bulk) {
             return $this->prepareBulk('DELETE');
         }
 
-        $request = $this->prepareRequest('DELETE');
-
-        return $this->client->request($request);
+        return $this->client->request($this->prepareRequest('DELETE', $url));
     }
 }

--- a/src/Model/ResponseModel.php
+++ b/src/Model/ResponseModel.php
@@ -4,53 +4,68 @@ namespace PanKrok\ShoperAppstoreBundle\Model;
 
 class ResponseModel
 {
-    private $code;
-    private $headers;
-    private $body;
+    private int $code;
+    private array $headers;
+    private string $body;
 
-    public function __construct($code, $headers, $body)
+    public function __construct(int $code, array $headers, string $body)
     {
-        $this->code = $code;
+        $this->code    = $code;
         $this->headers = $headers;
-        $this->body = $body;
+        $this->body    = $body;
     }
 
-    public function getCode()
+    public function getStatusCode(): int
     {
         return $this->code;
     }
 
-    public function getHeaders()
+    /**
+     * @deprecated since 1.2.0, use getStatusCode() instead.
+     */
+    public function getCode(): int
+    {
+        trigger_error(__METHOD__ . '() is deprecated, use getStatusCode() instead.', E_USER_DEPRECATED);
+        return $this->getStatusCode();
+    }
+
+    public function getHeaders(): array
     {
         return $this->headers;
     }
 
-    public function getBody()
+    public function getBody(): string
     {
         return $this->body;
     }
 
-    public function toArray()
+    public function toArray(): array
     {
-        try {
-            $return = json_decode($this->body, true);
-        } catch (\Exception $e) {
-            return $e;
+        if ($this->body === '') {
+            return [];
         }
 
-        return $return;
+        $decoded = json_decode($this->body, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException(
+                'Failed to decode API response body: ' . json_last_error_msg()
+            );
+        }
+
+        return $decoded ?? [];
     }
 
-    public function getBodyArray()
+    public function getBodyArray(): array
     {
         return $this->toArray();
     }
 
-    public function getAll()
+    public function getAll(): array
     {
         return [
-            'code' => $this->code,
-            'headers' => $this->headers,
+            'code'     => $this->code,
+            'headers'  => $this->headers,
             'response' => $this->body,
         ];
     }


### PR DESCRIPTION
## Summary

- **ApiController**: Full refactor — typed properties, canonical method names (`initFromRequest`, `refreshToken`, `useBasicAuth`, `bindShop`, `isOAuthMode`), deprecated aliases for all old names, `hash_equals()` HMAC verification, `performTokenRefresh()` using `expires_in` from server response
- **AccessTokens**: Removed `cascade: 'remove'` from the OneToOne relation (was silently deleting the Shop entity when a token was removed); fixed `__toString()` return type
- **PostBillingInstallEvent**: Fixed `getShop()` return type from undefined `Shop` to `Shops`
- **BillingInstallSubscriber**: Fixed wrong namespace `EventListener\PostBillingInstallEvent` → `Events\PostBillingInstallEvent` (caused class-not-found at runtime)
- **InstallSubscriber**: Single atomic `flush()` (was two), use `expires_in` from OAuth response (was hardcoded 30 days), update `shop_url`/`version` on reinstall path
- **UninstallSubscriber**: Single `flush()`, removed `setAccessTokens(null)` called on already-removed entity
- **UpgradeSubscriber**: Complete rewrite — only updates `version` and `shop_url`; removed OAuth exchange that used a non-existent `auth_code` from upgrade payload

## Bug fixes

| File | Bug |
|---|---|
| `AccessTokens` | `cascade: ['remove']` was deleting the Shop row when a token was removed |
| `PostBillingInstallEvent` | Return type referenced undefined class `Shop` |
| `BillingInstallSubscriber` | Wrong namespace caused class-not-found at runtime |
| `InstallSubscriber` | Double non-atomic flush; hardcoded token expiry; missing reinstall field updates |
| `UninstallSubscriber` | Double non-atomic flush; `setAccessTokens(null)` on removed entity |
| `UpgradeSubscriber` | Tried OAuth exchange with `auth_code` that does not exist in upgrade payload |
| `ApiController` | Missing `hash_equals()` (timing attack); hardcoded `now + 30days` expiry; no typed properties |

## Backward compatibility

All renamed `ApiController` methods keep their old names as deprecated aliases (`E_USER_DEPRECATED`). No breaking changes.

## Test plan

- [ ] Fresh install creates shop + token with correct `expires_at` from server response
- [ ] Reinstall (same shop) updates `shop_url`, `version`, replaces token atomically
- [ ] Uninstall sets `installed = false`, removes token, does not delete Shop
- [ ] Upgrade updates only `version` and `shop_url`, no token change
- [ ] Billing install dispatches `PostBillingInstallEvent` without class-not-found error
- [ ] Token CRON refresh selects expiring tokens and refreshes them
- [ ] Old method names (`setParams()`, `refreshShopToken()`, etc.) still work with deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)